### PR TITLE
fix: update admin redirects for channel integrations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,16 @@ Unreleased
 
 *
 
+0.1.10 – 2025-07-15
+******************
+
+Added
+=====
+
+*  Fix admin redirects for various channel integrations to use the correct app namespace.
+*  Upgrade Python Requirements
+
+
 0.1.9 – 2025-07-04
 ******************
 

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.9'
+__version__ = '0.1.10'

--- a/channel_integrations/blackboard/admin/__init__.py
+++ b/channel_integrations/blackboard/admin/__init__.py
@@ -105,7 +105,7 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.
                 {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
-            "/admin/blackboard/blackboardenterprisecustomerconfiguration"
+            "/admin/blackboard_channel/blackboardenterprisecustomerconfiguration"
         )
     force_content_metadata_transmission.label = "Force content metadata transmission"
 

--- a/channel_integrations/canvas/admin/__init__.py
+++ b/channel_integrations/canvas/admin/__init__.py
@@ -89,7 +89,7 @@ class CanvasEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mode
                 {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
-            "/admin/canvas/canvasenterprisecustomerconfiguration"
+            "/admin/canvas_channel/canvasenterprisecustomerconfiguration"
         )
     force_content_metadata_transmission.label = "Force content metadata transmission"
 

--- a/channel_integrations/cornerstone/admin/__init__.py
+++ b/channel_integrations/cornerstone/admin/__init__.py
@@ -95,7 +95,7 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin
                 {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
-            "/admin/cornerstone/cornerstoneenterprisecustomerconfiguration"
+            "/admin/cornerstone_channel/cornerstoneenterprisecustomerconfiguration"
         )
     force_content_metadata_transmission.label = "Force content metadata transmission"
 

--- a/channel_integrations/degreed2/admin/__init__.py
+++ b/channel_integrations/degreed2/admin/__init__.py
@@ -78,7 +78,9 @@ class Degreed2EnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mo
                 “<Degreed2EnterpriseCustomerConfiguration for Enterprise
                 {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
-        return HttpResponseRedirect('/admin/degreed2/degreed2enterprisecustomerconfiguration')
+        return HttpResponseRedirect(
+            '/admin/degreed2_channel/degreed2enterprisecustomerconfiguration'
+        )
     force_content_metadata_transmission.label = "Force content metadata transmission"
 
 

--- a/channel_integrations/moodle/admin/__init__.py
+++ b/channel_integrations/moodle/admin/__init__.py
@@ -69,7 +69,7 @@ class MoodleEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mode
                 {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
-            "/admin/moodle/moodleenterprisecustomerconfiguration"
+            "/admin/moodle_channel/moodleenterprisecustomerconfiguration"
         )
     force_content_metadata_transmission.label = "Force content metadata transmission"
 

--- a/channel_integrations/sap_success_factors/admin/__init__.py
+++ b/channel_integrations/sap_success_factors/admin/__init__.py
@@ -144,7 +144,7 @@ class SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(DjangoObjectActions,
                 {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
-            "/admin/sap_success_factors/sapsuccessfactorsenterprisecustomerconfiguration"
+            "/admin/sap_success_factors_channel/sapsuccessfactorsenterprisecustomerconfiguration"
         )
     force_content_metadata_transmission.label = "Force content metadata transmission"
 

--- a/channel_integrations/urls.py
+++ b/channel_integrations/urls.py
@@ -21,7 +21,7 @@ urlpatterns = [
         name='blackboard',
     ),
     re_path(
-        r'^integrated_channels/api/',
+        r'^channel_integrations/api/',
         include('channel_integrations.api.urls')
     ),
 ]

--- a/channel_integrations/xapi/admin/__init__.py
+++ b/channel_integrations/xapi/admin/__init__.py
@@ -75,5 +75,5 @@ class XAPILRSConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
                 “<XAPILRSConfiguration for Enterprise {obj.enterprise_customer.name}>”
                 was not updated successfully.''',
             )
-        return HttpResponseRedirect("/admin/xapi/xapilrsconfiguration/")
+        return HttpResponseRedirect("/admin/xapi_channel/xapilrsconfiguration/")
     force_content_metadata_transmission.label = "Force content metadata transmission"

--- a/tests/test_channel_integrations/test_api/test_cornerstone/test_views.py
+++ b/tests/test_channel_integrations/test_api/test_cornerstone/test_views.py
@@ -176,7 +176,7 @@ class CornerstoneLearnerInformationViewTests(APITest):
         )
         self.cornerstone_config.save()
         self.course_key = 'edX+DemoX'
-        self.path = settings.TEST_SERVER + '/integrated_channels/api/v1/cornerstone/save-learner-information'
+        self.path = settings.TEST_SERVER + '/channel_integrations/api/v1/cornerstone/save-learner-information'
 
     def test_save_learner_endpoint_happy_path(self):
         """

--- a/tests/test_channel_integrations/test_blackboard/test_admin.py
+++ b/tests/test_channel_integrations/test_blackboard/test_admin.py
@@ -1,0 +1,107 @@
+"""
+Tests for the Blackboard admin module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.admin.sites import AdminSite
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest, HttpResponseRedirect
+from django.test import TestCase
+from pytest import mark
+
+from channel_integrations.blackboard.admin import BlackboardEnterpriseCustomerConfigurationAdmin
+from channel_integrations.blackboard.models import BlackboardEnterpriseCustomerConfiguration
+from test_utils import factories
+
+
+@mark.django_db
+class TestBlackboardEnterpriseCustomerConfigurationAdmin(TestCase):
+    """
+    Tests for the ``BlackboardEnterpriseCustomerConfigurationAdmin`` admin class.
+    """
+
+    def setUp(self):
+        """
+        Set up test data.
+        """
+        super().setUp()
+        self.admin_site = AdminSite()
+        self.admin_instance = BlackboardEnterpriseCustomerConfigurationAdmin(
+            BlackboardEnterpriseCustomerConfiguration, self.admin_site
+        )
+        self.blackboard_config = factories.BlackboardEnterpriseCustomerConfigurationFactory()
+        self.request = HttpRequest()
+        self.request.session = {}
+        self.request._messages = MagicMock()  # pylint:disable=protected-access
+
+    def test_enterprise_customer_name(self):
+        """
+        Test the enterprise_customer_name method returns the correct name.
+        """
+        result = self.admin_instance.enterprise_customer_name(self.blackboard_config)
+        assert result == self.blackboard_config.enterprise_customer.name
+
+    def test_customer_oauth_authorization_url_with_url(self):
+        """
+        Test customer_oauth_authorization_url when oauth_authorization_url is available.
+        """
+        with patch.object(
+            type(self.blackboard_config), 'oauth_authorization_url',
+            new_callable=lambda: property(lambda self: 'https://example.com/auth')
+        ):
+            result = self.admin_instance.customer_oauth_authorization_url(self.blackboard_config)
+            assert 'href="https://example.com/auth"' in result
+            assert 'Authorize Link' in result
+
+    def test_customer_oauth_authorization_url_without_url(self):
+        """
+        Test customer_oauth_authorization_url when oauth_authorization_url is not available.
+        """
+        with patch.object(
+            type(self.blackboard_config), 'oauth_authorization_url',
+            new_callable=lambda: property(lambda self: None)
+        ):
+            result = self.admin_instance.customer_oauth_authorization_url(self.blackboard_config)
+            assert result is None
+
+    def test_force_content_metadata_transmission_success(self):
+        """
+        Test force_content_metadata_transmission method with successful save.
+        """
+        with patch.object(self.blackboard_config.enterprise_customer, 'save') as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.blackboard_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/blackboard_channel/blackboardenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_validation_error(self):
+        """
+        Test force_content_metadata_transmission method with ValidationError.
+        """
+        with patch.object(
+            self.blackboard_config.enterprise_customer, 'save',
+            side_effect=ValidationError("Test validation error")
+        ) as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.blackboard_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/blackboard_channel/blackboardenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_label(self):
+        """
+        Test that the force_content_metadata_transmission method has the correct label.
+        """
+        assert self.admin_instance.force_content_metadata_transmission.label == "Force content metadata transmission"

--- a/tests/test_channel_integrations/test_canvas/test_admin.py
+++ b/tests/test_channel_integrations/test_canvas/test_admin.py
@@ -1,0 +1,107 @@
+"""
+Tests for the Canvas admin module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.admin.sites import AdminSite
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest, HttpResponseRedirect
+from django.test import TestCase
+from pytest import mark
+
+from channel_integrations.canvas.admin import CanvasEnterpriseCustomerConfigurationAdmin
+from channel_integrations.canvas.models import CanvasEnterpriseCustomerConfiguration
+from test_utils import factories
+
+
+@mark.django_db
+class TestCanvasEnterpriseCustomerConfigurationAdmin(TestCase):
+    """
+    Tests for the ``CanvasEnterpriseCustomerConfigurationAdmin`` admin class.
+    """
+
+    def setUp(self):
+        """
+        Set up test data.
+        """
+        super().setUp()
+        self.admin_site = AdminSite()
+        self.admin_instance = CanvasEnterpriseCustomerConfigurationAdmin(
+            CanvasEnterpriseCustomerConfiguration, self.admin_site
+        )
+        self.canvas_config = factories.CanvasEnterpriseCustomerConfigurationFactory()
+        self.request = HttpRequest()
+        self.request.session = {}
+        self.request._messages = MagicMock()  # pylint:disable=protected-access
+
+    def test_enterprise_customer_name(self):
+        """
+        Test the enterprise_customer_name method returns the correct name.
+        """
+        result = self.admin_instance.enterprise_customer_name(self.canvas_config)
+        assert result == self.canvas_config.enterprise_customer.name
+
+    def test_customer_oauth_authorization_url_with_url(self):
+        """
+        Test customer_oauth_authorization_url when oauth_authorization_url is available.
+        """
+        with patch.object(
+            type(self.canvas_config), 'oauth_authorization_url',
+            new_callable=lambda: property(lambda self: 'https://example.com/auth')
+        ):
+            result = self.admin_instance.customer_oauth_authorization_url(self.canvas_config)
+            assert 'href="https://example.com/auth"' in result
+            assert 'Authorize Link' in result
+
+    def test_customer_oauth_authorization_url_without_url(self):
+        """
+        Test customer_oauth_authorization_url when oauth_authorization_url is not available.
+        """
+        with patch.object(
+            type(self.canvas_config), 'oauth_authorization_url',
+            new_callable=lambda: property(lambda self: None)
+        ):
+            result = self.admin_instance.customer_oauth_authorization_url(self.canvas_config)
+            assert result is None
+
+    def test_force_content_metadata_transmission_success(self):
+        """
+        Test force_content_metadata_transmission method with successful save.
+        """
+        with patch.object(self.canvas_config.enterprise_customer, 'save') as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.canvas_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/canvas_channel/canvasenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_validation_error(self):
+        """
+        Test force_content_metadata_transmission method with ValidationError.
+        """
+        with patch.object(
+            self.canvas_config.enterprise_customer, 'save',
+            side_effect=ValidationError("Test validation error")
+        ) as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.canvas_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/canvas_channel/canvasenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_label(self):
+        """
+        Test that the force_content_metadata_transmission method has the correct label.
+        """
+        assert self.admin_instance.force_content_metadata_transmission.label == "Force content metadata transmission"

--- a/tests/test_channel_integrations/test_cornerstone/test_admin.py
+++ b/tests/test_channel_integrations/test_cornerstone/test_admin.py
@@ -1,0 +1,77 @@
+"""
+Tests for the Cornerstone admin module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.admin.sites import AdminSite
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest, HttpResponseRedirect
+from django.test import TestCase
+from pytest import mark
+
+from channel_integrations.cornerstone.admin import CornerstoneEnterpriseCustomerConfigurationAdmin
+from channel_integrations.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
+from test_utils import factories
+
+
+@mark.django_db
+class TestCornerstoneEnterpriseCustomerConfigurationAdmin(TestCase):
+    """
+    Tests for the ``CornerstoneEnterpriseCustomerConfigurationAdmin`` admin class.
+    """
+
+    def setUp(self):
+        """
+        Set up test data.
+        """
+        super().setUp()
+        self.admin_site = AdminSite()
+        self.admin_instance = CornerstoneEnterpriseCustomerConfigurationAdmin(
+            CornerstoneEnterpriseCustomerConfiguration, self.admin_site
+        )
+        self.cornerstone_config = factories.CornerstoneEnterpriseCustomerConfigurationFactory()
+        self.request = HttpRequest()
+        self.request.session = {}
+        self.request._messages = MagicMock()  # pylint:disable=protected-access
+
+    def test_force_content_metadata_transmission_success(self):
+        """
+        Test force_content_metadata_transmission method with successful save.
+        """
+        with patch.object(self.cornerstone_config.enterprise_customer, 'save') as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.cornerstone_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/cornerstone_channel/cornerstoneenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_validation_error(self):
+        """
+        Test force_content_metadata_transmission method with ValidationError.
+        """
+        with patch.object(
+            self.cornerstone_config.enterprise_customer, 'save',
+            side_effect=ValidationError("Test validation error")
+        ) as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.cornerstone_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/cornerstone_channel/cornerstoneenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_label(self):
+        """
+        Test that the force_content_metadata_transmission method has the correct label.
+        """
+        assert self.admin_instance.force_content_metadata_transmission.label == "Force content metadata transmission"

--- a/tests/test_channel_integrations/test_degreed2/test_admin.py
+++ b/tests/test_channel_integrations/test_degreed2/test_admin.py
@@ -1,0 +1,77 @@
+"""
+Tests for the Degreed2 admin module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.admin.sites import AdminSite
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest, HttpResponseRedirect
+from django.test import TestCase
+from pytest import mark
+
+from channel_integrations.degreed2.admin import Degreed2EnterpriseCustomerConfigurationAdmin
+from channel_integrations.degreed2.models import Degreed2EnterpriseCustomerConfiguration
+from test_utils import factories
+
+
+@mark.django_db
+class TestDegreed2EnterpriseCustomerConfigurationAdmin(TestCase):
+    """
+    Tests for the ``Degreed2EnterpriseCustomerConfigurationAdmin`` admin class.
+    """
+
+    def setUp(self):
+        """
+        Set up test data.
+        """
+        super().setUp()
+        self.admin_site = AdminSite()
+        self.admin_instance = Degreed2EnterpriseCustomerConfigurationAdmin(
+            Degreed2EnterpriseCustomerConfiguration, self.admin_site
+        )
+        self.degreed2_config = factories.Degreed2EnterpriseCustomerConfigurationFactory()
+        self.request = HttpRequest()
+        self.request.session = {}
+        self.request._messages = MagicMock()  # pylint:disable=protected-access
+
+    def test_force_content_metadata_transmission_success(self):
+        """
+        Test force_content_metadata_transmission method with successful save.
+        """
+        with patch.object(self.degreed2_config.enterprise_customer, 'save') as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.degreed2_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/degreed2_channel/degreed2enterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_validation_error(self):
+        """
+        Test force_content_metadata_transmission method with ValidationError.
+        """
+        with patch.object(
+            self.degreed2_config.enterprise_customer, 'save',
+            side_effect=ValidationError("Test validation error")
+        ) as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.degreed2_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/degreed2_channel/degreed2enterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_label(self):
+        """
+        Test that the force_content_metadata_transmission method has the correct label.
+        """
+        assert self.admin_instance.force_content_metadata_transmission.label == "Force content metadata transmission"

--- a/tests/test_channel_integrations/test_moodle/test_admin.py
+++ b/tests/test_channel_integrations/test_moodle/test_admin.py
@@ -1,0 +1,77 @@
+"""
+Tests for the Moodle admin module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.admin.sites import AdminSite
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest, HttpResponseRedirect
+from django.test import TestCase
+from pytest import mark
+
+from channel_integrations.moodle.admin import MoodleEnterpriseCustomerConfigurationAdmin
+from channel_integrations.moodle.models import MoodleEnterpriseCustomerConfiguration
+from test_utils import factories
+
+
+@mark.django_db
+class TestMoodleEnterpriseCustomerConfigurationAdmin(TestCase):
+    """
+    Tests for the ``MoodleEnterpriseCustomerConfigurationAdmin`` admin class.
+    """
+
+    def setUp(self):
+        """
+        Set up test data.
+        """
+        super().setUp()
+        self.admin_site = AdminSite()
+        self.admin_instance = MoodleEnterpriseCustomerConfigurationAdmin(
+            MoodleEnterpriseCustomerConfiguration, self.admin_site
+        )
+        self.moodle_config = factories.MoodleEnterpriseCustomerConfigurationFactory()
+        self.request = HttpRequest()
+        self.request.session = {}
+        self.request._messages = MagicMock()  # pylint:disable=protected-access
+
+    def test_force_content_metadata_transmission_success(self):
+        """
+        Test force_content_metadata_transmission method with successful save.
+        """
+        with patch.object(self.moodle_config.enterprise_customer, 'save') as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.moodle_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/moodle_channel/moodleenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_validation_error(self):
+        """
+        Test force_content_metadata_transmission method with ValidationError.
+        """
+        with patch.object(
+            self.moodle_config.enterprise_customer, 'save',
+            side_effect=ValidationError("Test validation error")
+        ) as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.moodle_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/moodle_channel/moodleenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_label(self):
+        """
+        Test that the force_content_metadata_transmission method has the correct label.
+        """
+        assert self.admin_instance.force_content_metadata_transmission.label == "Force content metadata transmission"

--- a/tests/test_channel_integrations/test_sap_success_factors/test_admin.py
+++ b/tests/test_channel_integrations/test_sap_success_factors/test_admin.py
@@ -1,0 +1,77 @@
+"""
+Tests for the SAP Success Factors admin module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.admin.sites import AdminSite
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest, HttpResponseRedirect
+from django.test import TestCase
+from pytest import mark
+
+from channel_integrations.sap_success_factors.admin import SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin
+from channel_integrations.sap_success_factors.models import SAPSuccessFactorsEnterpriseCustomerConfiguration
+from test_utils import factories
+
+
+@mark.django_db
+class TestSAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(TestCase):
+    """
+    Tests for the ``SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin`` admin class.
+    """
+
+    def setUp(self):
+        """
+        Set up test data.
+        """
+        super().setUp()
+        self.admin_site = AdminSite()
+        self.admin_instance = SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(
+            SAPSuccessFactorsEnterpriseCustomerConfiguration, self.admin_site
+        )
+        self.sap_config = factories.SAPSuccessFactorsEnterpriseCustomerConfigurationFactory()
+        self.request = HttpRequest()
+        self.request.session = {}
+        self.request._messages = MagicMock()  # pylint:disable=protected-access
+
+    def test_force_content_metadata_transmission_success(self):
+        """
+        Test force_content_metadata_transmission method with successful save.
+        """
+        with patch.object(self.sap_config.enterprise_customer, 'save') as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.sap_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/sap_success_factors_channel/sapsuccessfactorsenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_validation_error(self):
+        """
+        Test force_content_metadata_transmission method with ValidationError.
+        """
+        with patch.object(
+            self.sap_config.enterprise_customer, 'save',
+            side_effect=ValidationError("Test validation error")
+        ) as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.sap_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/sap_success_factors_channel/sapsuccessfactorsenterprisecustomerconfiguration"
+
+    def test_force_content_metadata_transmission_label(self):
+        """
+        Test that the force_content_metadata_transmission method has the correct label.
+        """
+        assert self.admin_instance.force_content_metadata_transmission.label == "Force content metadata transmission"

--- a/tests/test_channel_integrations/test_xapi/test_admin.py
+++ b/tests/test_channel_integrations/test_xapi/test_admin.py
@@ -1,0 +1,82 @@
+"""
+Tests for the xAPI admin module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.admin.sites import AdminSite
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest, HttpResponseRedirect
+from django.test import TestCase
+from pytest import mark
+
+from channel_integrations.xapi.admin import XAPILRSConfigurationAdmin
+from channel_integrations.xapi.models import XAPILRSConfiguration
+from test_utils import factories
+
+
+@mark.django_db
+class TestXAPILRSConfigurationAdmin(TestCase):
+    """
+    Tests for the ``XAPILRSConfigurationAdmin`` admin class.
+    """
+
+    def setUp(self):
+        """
+        Set up test data.
+        """
+        super().setUp()
+        self.admin_site = AdminSite()
+        self.admin_instance = XAPILRSConfigurationAdmin(XAPILRSConfiguration, self.admin_site)
+        self.x_api_lrs_config = factories.XAPILRSConfigurationFactory()
+        self.request = HttpRequest()
+        self.request.session = {}
+        self.request._messages = MagicMock()  # pylint:disable=protected-access
+
+    def test_enterprise_customer_name(self):
+        """
+        Test the enterprise_customer_name method returns the correct name.
+        """
+        result = self.admin_instance.enterprise_customer_name(self.x_api_lrs_config)
+        assert result == self.x_api_lrs_config.enterprise_customer.name
+
+    def test_force_content_metadata_transmission_success(self):
+        """
+        Test force_content_metadata_transmission method with successful save.
+        """
+        with patch.object(self.x_api_lrs_config.enterprise_customer, 'save') as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.x_api_lrs_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/xapi_channel/xapilrsconfiguration/"
+
+    def test_force_content_metadata_transmission_validation_error(self):
+        """
+        Test force_content_metadata_transmission method with ValidationError.
+        """
+        with patch.object(
+            self.x_api_lrs_config.enterprise_customer, 'save',
+            side_effect=ValidationError("Test validation error")
+        ) as mock_save:
+            response = self.admin_instance.force_content_metadata_transmission(
+                self.request, self.x_api_lrs_config
+            )
+
+            # Verify the enterprise customer save was called
+            mock_save.assert_called_once()
+
+            # Verify the response is a redirect to the correct URL
+            assert isinstance(response, HttpResponseRedirect)
+            assert response.url == "/admin/xapi_channel/xapilrsconfiguration/"
+
+    def test_force_content_metadata_transmission_label(self):
+        """
+        Test that the force_content_metadata_transmission method has the correct label.
+        """
+        assert self.admin_instance.force_content_metadata_transmission.label == "Force content metadata transmission"


### PR DESCRIPTION
This commit updates the admin redirects when admin clicks the Force Content Metadata Transmission button for various channel integrations. The redirects now correctly point to the respective app namespaces.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [x] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
