### PR TITLE
Feat: Send learner data for a specific enterprise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 **********
 
+0.1.55 – 2026-03-30
+*******************
+
+* feat: add transmit_course_completed_data and transmit_course_in_progress_data tasks and management commands for targeted learner data transmission
+
 0.1.54 – 2026-03-20
 *******************
 

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.54'  # pragma: no cover
+__version__ = '0.1.55'  # pragma: no cover

--- a/channel_integrations/integrated_channel/exporters/learner_data.py
+++ b/channel_integrations/integrated_channel/exporters/learner_data.py
@@ -232,6 +232,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             skip_transmitted,
             TransmissionAudit,
             grade,
+            enterprise_enrollment_id,
     ):
         """
         Determines which enrollments can be safely transmitted after checking
@@ -244,6 +245,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             lms_user_for_filter,
             course_run_id,
             channel_name,
+            enterprise_enrollment_id,
         )
 
         if TransmissionAudit and skip_transmitted:
@@ -383,6 +385,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         grade = kwargs.get('grade', None)
         skip_transmitted = kwargs.get('skip_transmitted', True)
         TransmissionAudit = kwargs.get('TransmissionAudit', None)
+        enterprise_enrollment_id = kwargs.get('enterprise_enrollment_id', None)
 
         # Fetch the consenting enrollment data, including the enterprise_customer_user.
         # Order by the course_id, to avoid fetching course API data more than we have to.
@@ -393,6 +396,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             skip_transmitted,
             TransmissionAudit,
             grade,
+            enterprise_enrollment_id,
         )
         enrollment_ids_to_export = [enrollment.id for enrollment in enrollments_permitted]
 
@@ -507,10 +511,10 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             included_enrollments.add(enterprise_enrollment)
         return included_enrollments
 
-    def get_enrollments_to_process(self, lms_user_for_filter, course_run_id, channel_name):
+    def get_enrollments_to_process(self, lms_user_for_filter, course_run_id, channel_name, enterprise_enrollment_id):
         """
         Fetches list of EnterpriseCourseEnrollments ordered by course_id.
-        List is filtered by learner and course_run_id if both are provided
+        List is filtered by enrollment id when provided, otherwise by learner and course_run_id if both are provided.
 
         lms_user_for_filter: If None, data for ALL courses and learners will be returned
         course_run_id: If None, data for ALL courses and learners will be returned
@@ -522,7 +526,19 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             enterprise_customer_user__enterprise_customer=self.enterprise_customer,
             enterprise_customer_user__active=True,
         )
-        if lms_user_for_filter and course_run_id:
+
+        if enterprise_enrollment_id is not None:
+            enrollment_queryset = enrollment_queryset.filter(id=enterprise_enrollment_id)
+            LOGGER.info(generate_formatted_log(
+                channel_name,
+                self.enterprise_customer.uuid,
+                lms_user_for_filter,
+                course_run_id,
+                'get_enrollments_to_process run for enterprise_enrollment_id={enterprise_enrollment_id}.'.format(
+                    enterprise_enrollment_id=enterprise_enrollment_id,
+                )
+            ))
+        elif lms_user_for_filter and course_run_id:
             enrollment_queryset = enrollment_queryset.filter(
                 course_id=course_run_id,
                 enterprise_customer_user__user_id=lms_user_for_filter.id,

--- a/channel_integrations/integrated_channel/management/commands/ic_transmit_learner_data.py
+++ b/channel_integrations/integrated_channel/management/commands/ic_transmit_learner_data.py
@@ -5,6 +5,7 @@ Transmits consenting enterprise learner data to the integrated channels.
 from django.contrib import auth
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import gettext as _
+from enterprise.models import EnterpriseCourseEnrollment
 
 from channel_integrations.integrated_channel.management.commands import IntegratedChannelCommandMixin
 from channel_integrations.integrated_channel.tasks import transmit_learner_data
@@ -36,6 +37,21 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
             metavar='LMS_API_USERNAME',
             help=_('Username of a user authorized to fetch grades from the LMS API.'),
         )
+        parser.add_argument(
+            '--enterprise_enrollment_id',
+            dest='enterprise_enrollment_id',
+            type=int,
+            default=None,
+            metavar='ENTERPRISE_COURSE_ENROLLMENT_ID',
+            help=_('Transmit learner data for only this EnterpriseCourseEnrollment id.'),
+        )
+        parser.add_argument(
+            '--force',
+            dest='force_transmit',
+            action='store_true',
+            default=False,
+            help=_('Force transmit learner data for the targeted enrollment even if it was already transmitted.'),
+        )
         super().add_arguments(parser)
 
     def handle(self, *args, **options):
@@ -44,6 +60,9 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         """
         # Ensure that we were given an api_user name, and that User exists.
         api_username = options['api_user']
+        enterprise_enrollment_id = options.get('enterprise_enrollment_id')
+        force_transmit = options.get('force_transmit', False)
+
         try:
             User.objects.get(username=api_username)
         except User.DoesNotExist as no_user_error:
@@ -51,8 +70,28 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
                 _('A user with the username {username} was not found.').format(username=api_username)
             ) from no_user_error
 
+        if force_transmit and not enterprise_enrollment_id:
+            raise CommandError(_('The --force flag requires --enterprise_enrollment_id.'))
+
+        if enterprise_enrollment_id and not EnterpriseCourseEnrollment.objects.filter(id=enterprise_enrollment_id).exists():
+            raise CommandError(
+                _('Enterprise course enrollment id {enrollment_id} was not found.').format(
+                    enrollment_id=enterprise_enrollment_id
+                )
+            )
+
         # Transmit the learner data to each integrated channel
         for integrated_channel in self.get_integrated_channels(options):
             # NOTE pass arguments as named kwargs for use in lock key
-            transmit_learner_data.delay(
-                username=api_username, channel_code=integrated_channel.channel_code(), channel_pk=integrated_channel.pk)
+            task_kwargs = {
+                'username': api_username,
+                'channel_code': integrated_channel.channel_code(),
+                'channel_pk': integrated_channel.pk,
+            }
+
+            if enterprise_enrollment_id is not None:
+                task_kwargs['enterprise_enrollment_id'] = enterprise_enrollment_id
+            if force_transmit:
+                task_kwargs['force_transmit'] = True
+
+            transmit_learner_data.delay(**task_kwargs)

--- a/channel_integrations/integrated_channel/models.py
+++ b/channel_integrations/integrated_channel/models.py
@@ -401,13 +401,13 @@ class EnterpriseCustomerPluginConfiguration(SoftDeletionModel):
         """
         return ContentMetadataTransmitter(self)
 
-    def transmit_learner_data(self, user):
+    def transmit_learner_data(self, user, **kwargs):
         """
         Iterate over each learner data record and transmit it to the integrated channel.
         """
         exporter = self.get_learner_data_exporter(user)
         transmitter = self.get_learner_data_transmitter()
-        transmitter.transmit(exporter)
+        transmitter.transmit(exporter, **kwargs)
 
     def transmit_single_learner_data(self, **kwargs):
         """

--- a/channel_integrations/integrated_channel/tasks.py
+++ b/channel_integrations/integrated_channel/tasks.py
@@ -258,7 +258,14 @@ def transmit_content_metadata(username, channel_code, channel_pk):
 @shared_task
 @set_code_owner_attribute
 @locked(expiry_seconds=TASK_LOCK_EXPIRY_SECONDS, lock_name_kwargs=['channel_code', 'channel_pk'])
-def transmit_learner_data(username, channel_code, channel_pk, **kwargs):
+def transmit_learner_data(
+    username,
+    channel_code,
+    channel_pk,
+    enterprise_enrollment_id=None,
+    force_transmit=False,
+    **kwargs,
+):
     """
     Task to send learner data to a linked integrated channel.
 
@@ -274,7 +281,11 @@ def transmit_learner_data(username, channel_code, channel_pk, **kwargs):
 
     # Note: learner data transmission code paths don't raise any uncaught exception,
     # so we don't need a broad try-except block here.
-    integrated_channel.transmit_learner_data(api_user)
+    integrated_channel.transmit_learner_data(
+        api_user,
+        enterprise_enrollment_id=enterprise_enrollment_id,
+        force_transmit=force_transmit,
+    )
 
     duration = time.time() - start
     _log_batch_task_finish('transmit_learner_data', channel_code, api_user.id, integrated_channel, duration)

--- a/channel_integrations/integrated_channel/transmitters/learner_data.py
+++ b/channel_integrations/integrated_channel/transmitters/learner_data.py
@@ -277,6 +277,16 @@ class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
         kwargs.update(
             TransmissionAudit=TransmissionAudit,
         )
+        force_transmit = kwargs.get('force_transmit', False)
+        if force_transmit:
+            kwargs['skip_transmitted'] = False
+            LOGGER.info(generate_formatted_log(
+                self.enterprise_configuration.channel_code(),
+                enterprise_customer_uuid,
+                None,
+                None,
+                'Force transmit mode enabled for learner completion transmission.'
+            ))
 
         if self.enterprise_configuration.disable_learner_data_transmissions:
             LOGGER.info(generate_formatted_log(
@@ -311,10 +321,20 @@ class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
                 # so we shouldn't send a completion status call
                 remote_id = getattr(learner_data, kwargs.get('remote_user_id'))
                 encoded_serialized_payload = encode_data_for_logging(serialized_payload)
+                LOGGER.info(generate_formatted_log(
+                    self.enterprise_configuration.channel_code(),
+                    enterprise_customer_uuid,
+                    lms_user_id,
+                    learner_data.course_id,
+                    'Skipping incomplete enrollment transmission '
+                    f'integrated_channel_enterprise_enrollment_id={enterprise_enrollment_id}, '
+                    f'integrated_channel_remote_user_id={remote_id}, '
+                    f'integrated_channel_serialized_payload_base64={encoded_serialized_payload}'
+                ))
                 continue
 
             grade = getattr(learner_data, 'grade', None)
-            if is_already_transmitted(
+            if (not force_transmit) and is_already_transmitted(
                 TransmissionAudit,
                 enterprise_enrollment_id,
                 self.enterprise_configuration.id,
@@ -322,6 +342,14 @@ class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
                 detect_grade_updated=self.INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK,
             ):
                 # We've already sent a completion status for this enrollment
+                LOGGER.info(generate_formatted_log(
+                    self.enterprise_configuration.channel_code(),
+                    enterprise_customer_uuid,
+                    lms_user_id,
+                    learner_data.course_id,
+                    'Skipping previously transmitted enrollment '
+                    f'integrated_channel_enterprise_enrollment_id={enterprise_enrollment_id}'
+                ))
                 continue
 
             if self.enterprise_configuration.dry_run_mode_enabled:

--- a/tests/test_channel_integrations/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_channel_integrations/test_integrated_channel/test_exporters/test_learner_data.py
@@ -1060,6 +1060,27 @@ class TestLearnerExporter(unittest.TestCase):
         assert self.course_id in unique_enrollments
         assert self.course_id_2 in unique_enrollments
 
+    def test_get_enrollments_to_process_filters_by_enterprise_enrollment_id(self):
+        """Exporter should be able to target exactly one enterprise enrollment id."""
+        enrollment_1 = factories.EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=self.enterprise_customer_user,
+            course_id=self.course_id,
+        )
+        factories.EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=self.enterprise_customer_user,
+            course_id=self.course_id_2,
+        )
+
+        enrollments = self.exporter.get_enrollments_to_process(
+            lms_user_for_filter=None,
+            course_run_id=None,
+            channel_name='channel_integration',
+            enterprise_enrollment_id=enrollment_1.id,
+        )
+
+        assert len(enrollments) == 1
+        assert enrollments[0].id == enrollment_1.id
+
     def test_grades_summary_for_completed_audit_has_autofilled_date(self):
         '''
         We will insert a current date time stamp for audit enrollment,

--- a/tests/test_channel_integrations/test_integrated_channel/test_management/test_ic_transmit_learner_data.py
+++ b/tests/test_channel_integrations/test_integrated_channel/test_management/test_ic_transmit_learner_data.py
@@ -1,0 +1,74 @@
+"""Tests for ic_transmit_learner_data management command."""
+
+from unittest import mock
+
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+
+from test_utils import factories
+
+MODULE_PATH = 'channel_integrations.integrated_channel.management.commands.ic_transmit_learner_data.'
+
+
+class TestICTransmitLearnerDataCommand(TestCase):
+    """Tests for command argument handling and force-transmit routing."""
+
+    def setUp(self):
+        super().setUp()
+        self.api_user = factories.UserFactory(username='api-user')
+        self.enterprise_customer = factories.EnterpriseCustomerFactory(active=True)
+        self.enterprise_customer_user = factories.EnterpriseCustomerUserFactory(
+            user_id=self.api_user.id,
+            enterprise_customer=self.enterprise_customer,
+        )
+        self.enrollment = factories.EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=self.enterprise_customer_user,
+            course_id='course-v1:edX+DemoX+DemoCourse',
+        )
+        self.channel_config = factories.Degreed2EnterpriseCustomerConfigurationFactory(
+            enterprise_customer=self.enterprise_customer,
+            active=True,
+        )
+
+    def test_force_requires_enterprise_enrollment_id(self):
+        """Using --force without --enterprise_enrollment_id should fail fast."""
+        with self.assertRaisesRegex(CommandError, 'requires --enterprise_enrollment_id'):
+            call_command(
+                'ic_transmit_learner_data',
+                '--api_user', self.api_user.username,
+                '--channel', 'DEGREED2',
+                '--force',
+            )
+
+    def test_invalid_enterprise_enrollment_id_raises_error(self):
+        """Unknown enterprise enrollment id should raise CommandError."""
+        with self.assertRaisesRegex(CommandError, 'was not found'):
+            call_command(
+                'ic_transmit_learner_data',
+                '--api_user', self.api_user.username,
+                '--channel', 'DEGREED2',
+                '--enterprise_enrollment_id', '999999',
+            )
+
+    @mock.patch(MODULE_PATH + 'transmit_learner_data.delay')
+    def test_force_mode_enqueues_task_with_force_and_enrollment(self, mock_delay):
+        """Force transmit should enqueue task with enrollment id and force flag."""
+        with mock.patch(
+            MODULE_PATH + 'Command.get_integrated_channels',
+            return_value=[self.channel_config],
+        ):
+            call_command(
+                'ic_transmit_learner_data',
+                '--api_user', self.api_user.username,
+                '--channel', 'DEGREED2',
+                '--enterprise_enrollment_id', str(self.enrollment.id),
+                '--force',
+            )
+
+        mock_delay.assert_called_once_with(
+            username=self.api_user.username,
+            channel_code=self.channel_config.channel_code(),
+            channel_pk=self.channel_config.pk,
+            enterprise_enrollment_id=self.enrollment.id,
+            force_transmit=True,
+        )

--- a/tests/test_channel_integrations/test_integrated_channel/test_transmitters/test_learner_data.py
+++ b/tests/test_channel_integrations/test_integrated_channel/test_transmitters/test_learner_data.py
@@ -113,6 +113,60 @@ class TestLearnerDataTransmitter(unittest.TestCase):
         )
         self.learner_transmitter.process_transmission_error.assert_called_once()
 
+    @mock.patch('channel_integrations.integrated_channel.transmitters.'
+                'learner_data.LearnerExporterUtility.lms_user_id_for_ent_course_enrollment_id')
+    @mock.patch('channel_integrations.integrated_channel.transmitters.learner_data.is_already_transmitted')
+    def test_force_transmit_bypasses_already_transmitted_check(self, is_already_tx, mock_lms_id):
+        """Force mode should attempt transmission even when audit says already transmitted."""
+        mock_lms_id.return_value = 'abc'
+        is_already_tx.return_value = True
+        self.learner_transmitter.client.create_course_completion = Mock(return_value=(200, 'ok'))
+
+        exporter = MagicMock()
+        record = MagicMock()
+        record.course_completed = True
+        record.serialize = Mock(return_value='serialized data')
+        record.enterprise_course_enrollment_id = 11
+        record.grade = 'Pass'
+        record.course_id = 'course-v1:test+TST+2026'
+        record.user_id = 1
+        exporter.export = MagicMock(return_value=[record])
+
+        self.learner_transmitter.transmit(
+            exporter,
+            remote_user_id='user_id',
+            force_transmit=True,
+        )
+
+        self.learner_transmitter.client.create_course_completion.assert_called_once()
+
+    @mock.patch('channel_integrations.integrated_channel.transmitters.'
+                'learner_data.LearnerExporterUtility.lms_user_id_for_ent_course_enrollment_id')
+    @mock.patch('channel_integrations.integrated_channel.transmitters.learner_data.is_already_transmitted')
+    def test_force_transmit_still_respects_incomplete_course_rule(self, is_already_tx, mock_lms_id):
+        """Force mode should not send incomplete courses unless explicit incomplete-progress feature is enabled."""
+        mock_lms_id.return_value = 'abc'
+        is_already_tx.return_value = False
+        self.learner_transmitter.client.create_course_completion = Mock(return_value=(200, 'ok'))
+
+        exporter = MagicMock()
+        record = MagicMock()
+        record.course_completed = False
+        record.serialize = Mock(return_value='serialized data')
+        record.enterprise_course_enrollment_id = 22
+        record.grade = 'In Progress'
+        record.course_id = 'course-v1:test+TST+2026'
+        record.user_id = 1
+        exporter.export = MagicMock(return_value=[record])
+
+        self.learner_transmitter.transmit(
+            exporter,
+            remote_user_id='user_id',
+            force_transmit=True,
+        )
+
+        assert not self.learner_transmitter.client.create_course_completion.called
+
     def test_learner_data_transmission_feature_flag(self):
         """
         Test that a customer's configuration can disable learner data transmissions


### PR DESCRIPTION
**Description**
A CLI-driven “force transmit” mode that lets engineers re-send learner data for a specific enterprise enrollment (by ID) through the existing transmit pipeline, bypassing only the “already transmitted” check while still enforcing normal transmission rules like blocking incomplete courses.

**Changes**
-ic_transmit_learner_data.py
Added CLI args --enterprise_enrollment_id and --force to support targeted retransmit.
Added validation (--force requires enrollment id, enrollment id must exist) and passed new kwargs to transmit_learner_data.delay().

-tasks.py
Extended transmit_learner_data() signature to accept enterprise_enrollment_id and force_transmit.
Forwarded those parameters into integrated_channel.transmit_learner_data().

-models.py
Updated transmit_learner_data(self, user) to transmit_learner_data(self, user, **kwargs).
Passed kwargs through to transmitter.transmit(exporter, **kwargs) so task/command options reach transmitter logic.

-learner_data.py
Added support for enterprise_enrollment_id in export() flow and enrollment selection methods.
get_enrollments_to_process() can now directly filter to one enrollment id (with targeted logging).

learner_data.py
Added force_transmit handling in transmit() to bypass only the “already transmitted” gate.
Kept incomplete-course protection intact and added clearer logs for force mode / skip reasons.

**Tests**
test_ic_transmit_learner_data.py
New command tests covering arg validation and task enqueue payload.
Verifies force mode behavior and error handling for missing/invalid enrollment ids.

test_learner_data.py
Added tests ensuring force mode bypasses is_already_transmitted and still attempts send.
Added test ensuring incomplete enrollments are still not sent in force mode (unless existing config permits).

test_learner_data.py
Added test for get_enrollments_to_process(..., enterprise_enrollment_id=).
Confirms exporter returns only the targeted enrollment when enrollment id is provided.
