### PR TITLE
feat: ENT-11628 API for Org ID management + Django Model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+0.1.57 – 2026-04-10
+*******************
+
+* feat: add TPA org allowlist API with dedicated ``tpa_org_allowlist_admin`` role
+* feat: validate endpoint derives enterprise scope from caller credentials, no ``enterprise_customer`` param required
+
 0.1.56 – 2026-03-30
 *******************
 * feat: add transmit_course_completed_data and transmit_course_in_progress_data tasks and management commands for targeted learner data transmission

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.56'  # pragma: no cover
+__version__ = '0.1.57'  # pragma: no cover

--- a/channel_integrations/api/v1/tpa_org_allowlist/serializers.py
+++ b/channel_integrations/api/v1/tpa_org_allowlist/serializers.py
@@ -1,0 +1,20 @@
+"""
+Serializer for TPA Org Allowlist.
+"""
+from rest_framework import serializers
+from channel_integrations.integrated_channel.models import TpaOrgAllowlist
+
+
+class TpaOrgAllowlistSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = TpaOrgAllowlist
+        fields = (
+            'id',
+            'enterprise_customer',
+            'tpa_org_id',
+            'demo_account',
+            'created',
+            'modified',
+        )
+        read_only_fields = ('id', 'created', 'modified')

--- a/channel_integrations/api/v1/tpa_org_allowlist/urls.py
+++ b/channel_integrations/api/v1/tpa_org_allowlist/urls.py
@@ -1,0 +1,10 @@
+"""
+URL definitions for TPA Org Allowlist API.
+"""
+from rest_framework import routers
+from .views import TpaOrgAllowlistViewSet
+
+app_name = 'tpa_org_allowlist'
+router = routers.DefaultRouter()
+router.register(r'', TpaOrgAllowlistViewSet, basename='tpa-org-allowlist')
+urlpatterns = router.urls

--- a/channel_integrations/api/v1/tpa_org_allowlist/views.py
+++ b/channel_integrations/api/v1/tpa_org_allowlist/views.py
@@ -1,0 +1,110 @@
+"""
+Viewset for TPA Org Allowlist.
+"""
+from uuid import UUID
+
+import crum
+from rest_framework import mixins, permissions, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from edx_rbac.utils import has_access_to_all
+
+from channel_integrations.api.v1.mixins import PermissionRequiredForIntegratedChannelMixin
+from channel_integrations.integrated_channel.models import TpaOrgAllowlist
+from .serializers import TpaOrgAllowlistSerializer
+
+
+class TpaOrgAllowlistViewSet(
+    PermissionRequiredForIntegratedChannelMixin,
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    """
+    Viewset for managing TPA org allowlist entries.
+    Supports create, list, retrieve, destroy, and validate.
+    """
+    serializer_class = TpaOrgAllowlistSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+    permission_required = 'enterprise.can_access_admin_dashboard'
+    allowed_roles = ['tpa_org_allowlist_admin']
+    configuration_model = TpaOrgAllowlist
+    pagination_class = None
+
+    def check_permissions(self, request):
+        """
+        Use accessible_contexts for all actions (not just list) so that
+        DB-based role assignments are honoured without requiring the django-rules
+        permission backend or JWT predicates.
+
+        Superusers bypass the check. All other users must have at least one
+        accessible enterprise context via their role assignments.
+        """
+        crum.set_current_request(request)
+        if request.user.is_superuser:
+            return
+        if not self.accessible_contexts:
+            self.permission_denied(request)
+
+    def get_queryset(self):
+        """
+        For list actions, delegate to the parent mixin which handles enterprise
+        scoping via accessible_contexts and the enterprise_customer query param.
+
+        For retrieve and destroy, the parent mixin returns base_queryset without
+        enterprise scoping — override to always restrict to the caller's accessible
+        enterprise contexts so entries from other enterprises return 404.
+        """
+        if self.action == 'list':
+            return super().get_queryset()
+        qs = TpaOrgAllowlist.objects.all()
+        if not has_access_to_all(self.accessible_contexts):
+            qs = qs.filter(enterprise_customer_id__in=self.accessible_contexts)
+        return qs
+
+    @action(detail=False, methods=['get'], url_path='validate')
+    def validate(self, request):
+        """
+        Returns 200 if the given tpa_org_id is in the allowlist, 404 otherwise.
+        Intended for use by Auth0 Actions at login time.
+
+        The enterprise customer scope is derived from the caller's credentials.
+        Tokens scoped to a specific enterprise (the normal service-user case) do not
+        need to pass enterprise_customer. Tokens with global access (ALL_ACCESS_CONTEXT)
+        must supply enterprise_customer explicitly.
+        """
+        tpa_org_id = request.query_params.get('tpa_org_id')
+        if not tpa_org_id:
+            return Response(
+                {'detail': 'tpa_org_id is required.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        enterprise_uuids = self.accessible_contexts
+
+        if has_access_to_all(enterprise_uuids):
+            enterprise_customer_param = request.query_params.get('enterprise_customer')
+            if not enterprise_customer_param:
+                return Response(
+                    {'detail': 'enterprise_customer is required for tokens with global access.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            try:
+                enterprise_uuids = {str(UUID(enterprise_customer_param))}
+            except (ValueError, AttributeError):
+                return Response(
+                    {'detail': f'{enterprise_customer_param} is not a valid UUID.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        exists = TpaOrgAllowlist.objects.filter(
+            enterprise_customer_id__in=enterprise_uuids,
+            tpa_org_id=tpa_org_id,
+        ).exists()
+
+        if exists:
+            return Response({'detail': 'Authorised.'}, status=status.HTTP_200_OK)
+        return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)

--- a/channel_integrations/api/v1/urls.py
+++ b/channel_integrations/api/v1/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     path('configs/health-check', IntegratedChannelHealthCheckView.as_view(), name='health_check'),
     path('configs/', IntegratedChannelsBaseViewSet.as_view({'get': 'list'}), name='configs'),
     path('logs/', include('channel_integrations.api.v1.logs.urls')),
+    path('tpa-org-allowlist/', include('channel_integrations.api.v1.tpa_org_allowlist.urls')),
 ]

--- a/channel_integrations/integrated_channel/constants.py
+++ b/channel_integrations/integrated_channel/constants.py
@@ -4,3 +4,5 @@ Constants used by the integrated channels
 
 ISO_8601_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 TASK_LOCK_EXPIRY_SECONDS = 60 * 60 * 12
+
+TPA_ORG_ALLOWLIST_ADMIN_ROLE = 'tpa_org_allowlist_admin'

--- a/channel_integrations/integrated_channel/migrations/0010_tpaorgallowlist.py
+++ b/channel_integrations/integrated_channel/migrations/0010_tpaorgallowlist.py
@@ -1,0 +1,85 @@
+# Generated migration for TpaOrgAllowlist model
+
+import django.db.models.deletion
+import django.utils.timezone
+import model_utils.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "channel_integration",
+            "0009_remove_enterprisewebhookconfiguration_webhook_auth_token_and_more",
+        ),
+        ("enterprise", "__first__"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TpaOrgAllowlist",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "created",
+                    model_utils.fields.AutoCreatedField(
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name="created",
+                    ),
+                ),
+                (
+                    "modified",
+                    model_utils.fields.AutoLastModifiedField(
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name="modified",
+                    ),
+                ),
+                (
+                    "tpa_org_id",
+                    models.CharField(
+                        help_text="Org UUID as asserted by the IdP in the SAML attribute",
+                        max_length=255,
+                    ),
+                ),
+                (
+                    "demo_account",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Whether this is a demo/trial organisation",
+                    ),
+                ),
+                (
+                    "enterprise_customer",
+                    models.ForeignKey(
+                        help_text="Enterprise customer this org is permitted to access",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="tpa_org_allowlist",
+                        to="enterprise.enterprisecustomer",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "TPA Org Allowlist Entry",
+                "verbose_name_plural": "TPA Org Allowlist Entries",
+                "app_label": "channel_integration",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="tpaorgallowlist",
+            constraint=models.UniqueConstraint(
+                fields=["enterprise_customer", "tpa_org_id"],
+                name="unique_tpa_org_per_enterprise",
+            ),
+        ),
+    ]

--- a/channel_integrations/integrated_channel/migrations/0011_create_tpa_org_allowlist_admin_role.py
+++ b/channel_integrations/integrated_channel/migrations/0011_create_tpa_org_allowlist_admin_role.py
@@ -1,0 +1,31 @@
+"""
+Data migration to ensure the tpa_org_allowlist_admin SystemWideEnterpriseRole exists.
+"""
+from django.db import migrations
+
+
+def create_tpa_org_allowlist_admin_role(apps, schema_editor):
+    """Create the tpa_org_allowlist_admin role if it does not already exist."""
+    SystemWideEnterpriseRole = apps.get_model('enterprise', 'SystemWideEnterpriseRole')
+    SystemWideEnterpriseRole.objects.get_or_create(name='tpa_org_allowlist_admin')
+
+
+def delete_tpa_org_allowlist_admin_role(apps, schema_editor):
+    """Remove the tpa_org_allowlist_admin role (reverse migration)."""
+    SystemWideEnterpriseRole = apps.get_model('enterprise', 'SystemWideEnterpriseRole')
+    SystemWideEnterpriseRole.objects.filter(name='tpa_org_allowlist_admin').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('channel_integration', '0010_tpaorgallowlist'),
+        ('enterprise', '__first__'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_tpa_org_allowlist_admin_role,
+            reverse_code=delete_tpa_org_allowlist_admin_role,
+        ),
+    ]

--- a/channel_integrations/integrated_channel/models.py
+++ b/channel_integrations/integrated_channel/models.py
@@ -1261,3 +1261,39 @@ class WebhookTransmissionQueue(TimeStampedModel):
             models.Index(fields=['event_type']),
             models.Index(fields=['deduplication_key']),
         ]
+
+
+class TpaOrgAllowlist(TimeStampedModel):
+    """
+    Allowlist of third-party auth org IDs permitted to access edX for an enterprise customer.
+
+    Each row permits users asserting `tpa_org_id` to authenticate into the associated
+    enterprise customer's edX environment.
+
+    .. no_pii:
+    """
+    enterprise_customer = models.ForeignKey(
+        EnterpriseCustomer,
+        on_delete=models.CASCADE,
+        related_name='tpa_org_allowlist',
+        help_text='Enterprise customer this org is permitted to access',
+    )
+    tpa_org_id = models.CharField(
+        max_length=255,
+        help_text='Org UUID as asserted by the IdP in the SAML attribute',
+    )
+    demo_account = models.BooleanField(
+        default=False,
+        help_text='Whether this is a demo/trial organisation',
+    )
+
+    class Meta:
+        app_label = 'channel_integration'
+        verbose_name = 'TPA Org Allowlist Entry'
+        verbose_name_plural = 'TPA Org Allowlist Entries'
+        constraints = [
+            models.UniqueConstraint(
+                fields=['enterprise_customer', 'tpa_org_id'],
+                name='unique_tpa_org_per_enterprise',
+            )
+        ]

--- a/docs/how-tos/index.rst
+++ b/docs/how-tos/index.rst
@@ -6,3 +6,4 @@ How-tos
 
 	percipio_webhook_payload
 	celery_queue_configuration
+	tpa_org_allowlist_api

--- a/docs/how-tos/tpa_org_allowlist_api.rst
+++ b/docs/how-tos/tpa_org_allowlist_api.rst
@@ -1,0 +1,269 @@
+TPA Org Allowlist API
+#####################
+
+The TPA Org Allowlist API lets you manage which third-party auth (TPA) org IDs are
+permitted to log in to an enterprise customer's edX environment. The Auth0 Post-Login
+Action calls the ``validate`` endpoint on every login to decide whether to allow or
+deny the attempt.
+
+Endpoints
+*********
+
+All endpoints are under ``/channel_integrations/api/v1/tpa-org-allowlist/``.
+
+.. list-table::
+   :widths: 10 40 50
+   :header-rows: 1
+
+   * - Method
+     - URL
+     - Description
+   * - ``GET``
+     - ``/tpa-org-allowlist/?enterprise_customer=<uuid>``
+     - List all allowlisted org IDs for an enterprise customer
+   * - ``POST``
+     - ``/tpa-org-allowlist/``
+     - Add an org ID to the allowlist
+   * - ``GET``
+     - ``/tpa-org-allowlist/<id>/``
+     - Retrieve a single allowlist entry
+   * - ``DELETE``
+     - ``/tpa-org-allowlist/<id>/``
+     - Remove an org ID from the allowlist
+   * - ``GET``
+     - ``/tpa-org-allowlist/validate/?tpa_org_id=<uuid>``
+     - Returns ``200`` if the org is allowlisted, ``404`` if not
+
+The ``validate`` endpoint is the one called by the Auth0 Action at login time. It only
+checks the HTTP status code — ``200`` means authorised, ``404`` means denied.
+
+Request / response examples
+****************************
+
+Add an org (``POST /tpa-org-allowlist/``)
+==========================================
+
+.. code-block:: json
+
+   {
+     "enterprise_customer": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+     "tpa_org_id": "11111111-2222-3333-4444-555555555555",
+     "demo_account": false
+   }
+
+Returns ``201 Created`` with the created record, or ``400 Bad Request`` if the
+``(enterprise_customer, tpa_org_id)`` combination already exists.
+
+Validate an org (``GET /tpa-org-allowlist/validate/``)
+=======================================================
+
+The enterprise scope is derived automatically from the caller's credentials — the
+service user's token encodes which enterprise it belongs to, so no ``enterprise_customer``
+parameter is needed:
+
+.. code-block:: bash
+
+   GET /channel_integrations/api/v1/tpa-org-allowlist/validate/?tpa_org_id=11111111-2222-3333-4444-555555555555
+   Authorization: Bearer <service-user-token>
+
+Returns ``200 {"detail": "Authorised."}`` if the org is in the allowlist, or
+``404 {"detail": "Not found."}`` if it is not.
+
+Callers whose token has global (superuser) access must supply ``enterprise_customer``
+explicitly — the API cannot infer a single enterprise from an unrestricted token:
+
+.. code-block:: bash
+
+   GET /channel_integrations/api/v1/tpa-org-allowlist/validate/
+       ?enterprise_customer=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+       &tpa_org_id=11111111-2222-3333-4444-555555555555
+
+Authentication and permissions
+*******************************
+
+All endpoints require a valid JWT (``Authorization: Bearer <token>``). Beyond
+authentication, callers also need the ``tpa_org_allowlist_admin`` role.
+
+This is a dedicated role — separate from the general ``enterprise_admin`` role — so
+that it can be granted narrowly. The role is checked in two ways:
+
+- **Implicit (JWT):** The JWT ``roles`` claim must contain
+  ``tpa_org_allowlist_admin:<enterprise_customer_uuid>``.
+- **Explicit (database):** A ``SystemWideEnterpriseUserRoleAssignment`` row must exist
+  linking the user to the ``tpa_org_allowlist_admin`` role for the relevant enterprise.
+
+Setting up the service user
+***************************
+
+The Auth0 Post-Login Action needs a long-lived bearer token to call ``validate``.
+The recommended approach is a dedicated edX service account so that the token scope
+is limited to this API.
+
+Via the Django admin UI
+=======================
+
+Step 1 — Create the service account user
+-----------------------------------------
+
+Go to **Django admin → Authentication and Authorization → Users → Add user**.
+
+Fill in:
+
+- **Username:** ``auth0-tpa-allowlist-svc``
+- **Password:** generate a strong random password (it will never be used interactively)
+
+Save, then on the detail page ensure **Active** is checked. Leave ``Staff status`` and
+``Superuser status`` unchecked.
+
+Step 2 — Create an OAuth2 application
+---------------------------------------
+
+Go to **Django admin → Django OAuth Toolkit → Applications → Add application**.
+
+Fill in:
+
+- **User:** ``auth0-tpa-allowlist-svc`` (the user created above)
+- **Client type:** ``Confidential``
+- **Authorization grant type:** ``Client credentials``
+- **Name:** ``auth0-tpa-allowlist-svc``
+
+Save and note the generated **Client id** and **Client secret**.
+
+Step 3 — Obtain a bearer token
+--------------------------------
+
+Exchange the client credentials for a token:
+
+.. code-block:: bash
+
+   curl -X POST https://<edx-host>/oauth2/access_token \
+     -d "client_id=<client_id>&client_secret=<client_secret>&grant_type=client_credentials"
+
+Store the ``access_token`` from the response — this goes into the Auth0 Action Secret
+``TPA_ORG_API_TOKEN``.
+
+.. note::
+   Check ``expires_in`` against your Auth0 Action caching policy. If the token expires
+   before the Action cache is refreshed, subsequent logins will get 401 errors. Either
+   configure a sufficiently long token lifetime in the OAuth2 application settings, or
+   add token-refresh logic to the Action.
+
+Step 4 — Assign the role
+--------------------------
+
+Go to **Django admin → Enterprise → System wide enterprise user role assignments →
+Add system wide enterprise user role assignment**.
+
+Fill in:
+
+- **User:** ``auth0-tpa-allowlist-svc``
+- **Role:** ``tpa_org_allowlist_admin`` (create it if it does not yet exist)
+- **Enterprise customer:** select the target enterprise customer (e.g. Skillsoft)
+
+Save. This role assignment is what allows the service user to call ``validate`` without
+passing ``enterprise_customer`` as a query parameter — the enterprise scope is read
+directly from the assignment.
+
+Step 5 — Configure Auth0 Action Secrets
+-----------------------------------------
+
+See `Configure Auth0 Action Secrets`_ below.
+
+Via the Django shell
+====================
+
+Step 1 — Create the service account user
+-----------------------------------------
+
+.. code-block:: python
+
+   from django.contrib.auth import get_user_model
+   User = get_user_model()
+   user = User.objects.create_user(
+       username='auth0-tpa-allowlist-svc',
+       email='auth0-tpa-allowlist-svc@example.com',
+       is_active=True,
+   )
+
+Step 2 — Issue an OAuth2 application and obtain a token
+---------------------------------------------------------
+
+.. code-block:: python
+
+   from oauth2_provider.models import Application
+   import secrets
+
+   app = Application.objects.create(
+       user=user,
+       name='auth0-tpa-allowlist-svc',
+       client_type=Application.CLIENT_CONFIDENTIAL,
+       authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+       client_secret=secrets.token_urlsafe(40),
+   )
+   print('client_id:', app.client_id)
+   print('client_secret:', app.client_secret)
+
+Then exchange for a token:
+
+.. code-block:: bash
+
+   curl -X POST https://<edx-host>/oauth2/access_token \
+     -d "client_id=<client_id>&client_secret=<client_secret>&grant_type=client_credentials"
+
+Store the ``access_token`` as ``TPA_ORG_API_TOKEN`` in Auth0 Action Secrets.
+
+Step 3 — Assign the role
+--------------------------
+
+.. code-block:: python
+
+   from enterprise.models import EnterpriseCustomer, SystemWideEnterpriseRole, SystemWideEnterpriseUserRoleAssignment
+
+   enterprise_customer = EnterpriseCustomer.objects.get(uuid='aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+   role, _ = SystemWideEnterpriseRole.objects.get_or_create(name='tpa_org_allowlist_admin')
+   SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
+       user=user,
+       role=role,
+       enterprise_customer=enterprise_customer,
+   )
+
+.. _Configure Auth0 Action Secrets:
+
+Configure Auth0 Action Secrets
+================================
+
+Add the following secrets to the Auth0 Post-Login Action:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Secret name
+     - Value
+   * - ``TPA_ORG_API_URL``
+     - Base URL, e.g. ``https://courses.edx.org/channel_integrations/api/v1/tpa-org-allowlist``
+   * - ``TPA_ORG_API_TOKEN``
+     - The bearer token obtained in Step 2
+
+Note that ``TPA_ENTERPRISE_CUSTOMER_UUID`` is no longer needed — the enterprise scope
+is derived from the service user's role assignment, not from a query parameter.
+
+The Action calls ``validate`` like this:
+
+.. code-block:: javascript
+
+   const response = await fetch(
+     `${event.secrets.TPA_ORG_API_URL}/validate/?tpa_org_id=${percipioOrganizationUuid}`,
+     { headers: { Authorization: `Bearer ${event.secrets.TPA_ORG_API_TOKEN}` } }
+   );
+
+   if (response.status === 404) {
+     api.access.deny('Unauthorized organisation.');
+     return;
+   }
+   if (!response.ok) {
+     // Fail closed: deny if the API is unreachable
+     api.access.deny('Unable to verify organisation authorization.');
+     return;
+   }
+   // 200 — authorised, continue

--- a/mock_apps/enterprise/models.py
+++ b/mock_apps/enterprise/models.py
@@ -689,6 +689,14 @@ class EnterpriseCustomerUser(TimeStampedModel):
             return True
         return False
 
+    @classmethod
+    def get_active_enterprise_users(cls, user_id, enterprise_customer_uuids=None):
+        """Return active EnterpriseCustomerUser records for the given user."""
+        kwargs = {'user_id': user_id, 'active': True}
+        if enterprise_customer_uuids is not None:
+            kwargs['enterprise_customer__in'] = enterprise_customer_uuids
+        return cls.objects.filter(**kwargs)
+
     class Meta:
         app_label = 'enterprise'
 
@@ -758,6 +766,20 @@ class SystemWideEnterpriseUserRoleAssignment(UserRoleAssignment):
         related_name="system_wide_role_assignments",
         on_delete=models.CASCADE,
     )
+
+    enterprise_customer = models.ForeignKey(
+        EnterpriseCustomer,
+        null=True,
+        blank=True,
+        related_name="system_wide_role_assignments",
+        on_delete=models.CASCADE,
+    )
+
+    def get_context(self):
+        """Return a list containing the enterprise customer UUID string, or None."""
+        if self.enterprise_customer_id:
+            return [str(self.enterprise_customer.uuid)]
+        return None
 
     @classmethod
     def get_distinct_assignments_by_role_name(cls, user, role_names=None):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -88,6 +88,7 @@ django-oauth-toolkit==3.2.0
     # via -r requirements/base.in
 django-object-actions==5.0.0
     # via -r requirements/base.in
+    # via -r requirements/base.in
 django-simple-history==3.11.0
     # via -r requirements/base.in
 django-waffle==5.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -326,6 +326,7 @@ requests-oauthlib==2.0.0
     # via social-auth-core
 responses==0.26.0
     # via -r requirements/test.in
+    # via -r requirements/base.txt
 s3transfer==0.16.0
     # via
     #   -r requirements/base.txt

--- a/tests/test_channel_integrations/test_integrated_channel/test_tpa_org_allowlist.py
+++ b/tests/test_channel_integrations/test_integrated_channel/test_tpa_org_allowlist.py
@@ -1,0 +1,277 @@
+"""
+Tests for the TPA Org Allowlist API.
+"""
+from uuid import uuid4
+
+import pytest
+from rest_framework.test import APIClient
+
+from django.contrib.auth import get_user_model
+
+from enterprise.models import SystemWideEnterpriseRole, SystemWideEnterpriseUserRoleAssignment
+
+from channel_integrations.integrated_channel.constants import TPA_ORG_ALLOWLIST_ADMIN_ROLE
+from channel_integrations.integrated_channel.models import TpaOrgAllowlist
+from test_utils.factories import EnterpriseCustomerFactory, UserFactory
+
+User = get_user_model()
+
+TPA_ORG_ALLOWLIST_URL = '/channel_integrations/api/v1/tpa-org-allowlist/'
+
+
+@pytest.fixture
+def enterprise_customer():
+    return EnterpriseCustomerFactory()
+
+
+@pytest.fixture
+def admin_user():
+    user = UserFactory(username='tpa_test_admin', is_active=True, is_superuser=True, is_staff=True)
+    user.set_password('password')
+    user.save()
+    return user
+
+
+@pytest.fixture
+def regular_user():
+    """Non-superuser without any role assignment."""
+    user = UserFactory(username='tpa_test_regular', is_active=True, is_superuser=False, is_staff=False)
+    user.set_password('password')
+    user.save()
+    return user
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def authenticated_client(api_client, admin_user):  # pylint: disable=redefined-outer-name
+    """
+    Return an API client authenticated as a superuser (bypasses permission checks).
+    """
+    api_client.force_authenticate(user=admin_user)
+    return api_client
+
+
+@pytest.mark.django_db
+class TestTpaOrgAllowlistCreate:
+    """Tests for POST /tpa-org-allowlist/"""
+
+    def test_create_entry_returns_201(self, authenticated_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """POST with valid data creates an entry and returns 201."""
+        payload = {
+            'enterprise_customer': str(enterprise_customer.uuid),
+            'tpa_org_id': str(uuid4()),
+            'demo_account': False,
+        }
+        response = authenticated_client.post(TPA_ORG_ALLOWLIST_URL, data=payload, format='json')
+        assert response.status_code == 201
+        assert TpaOrgAllowlist.objects.filter(
+            enterprise_customer=enterprise_customer,
+            tpa_org_id=payload['tpa_org_id'],
+        ).exists()
+
+    def test_create_duplicate_returns_400(self, authenticated_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """POST with duplicate (enterprise_customer, tpa_org_id) returns 400."""
+        tpa_org_id = str(uuid4())
+        TpaOrgAllowlist.objects.create(
+            enterprise_customer=enterprise_customer,
+            tpa_org_id=tpa_org_id,
+        )
+        payload = {
+            'enterprise_customer': str(enterprise_customer.uuid),
+            'tpa_org_id': tpa_org_id,
+        }
+        response = authenticated_client.post(TPA_ORG_ALLOWLIST_URL, data=payload, format='json')
+        assert response.status_code == 400
+
+
+@pytest.mark.django_db
+class TestTpaOrgAllowlistList:
+    """Tests for GET /tpa-org-allowlist/?enterprise_customer=<uuid>"""
+
+    def test_list_scoped_to_enterprise_customer(self, authenticated_client):  # pylint: disable=redefined-outer-name
+        """GET with enterprise_customer param returns only entries for that customer."""
+        ec1 = EnterpriseCustomerFactory()
+        ec2 = EnterpriseCustomerFactory()
+
+        TpaOrgAllowlist.objects.create(enterprise_customer=ec1, tpa_org_id=str(uuid4()))
+        TpaOrgAllowlist.objects.create(enterprise_customer=ec1, tpa_org_id=str(uuid4()))
+        TpaOrgAllowlist.objects.create(enterprise_customer=ec2, tpa_org_id=str(uuid4()))
+
+        response = authenticated_client.get(
+            TPA_ORG_ALLOWLIST_URL, {'enterprise_customer': str(ec1.uuid)}
+        )
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        for entry in response.data:
+            assert str(entry['enterprise_customer']) == str(ec1.uuid)
+
+
+@pytest.mark.django_db
+class TestTpaOrgAllowlistDelete:
+    """Tests for DELETE /tpa-org-allowlist/<id>/"""
+
+    def test_delete_returns_204(self, authenticated_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """DELETE on existing entry removes it and returns 204."""
+        entry = TpaOrgAllowlist.objects.create(
+            enterprise_customer=enterprise_customer,
+            tpa_org_id=str(uuid4()),
+        )
+        url = f'{TPA_ORG_ALLOWLIST_URL}{entry.id}/'
+        response = authenticated_client.delete(url)
+        assert response.status_code == 204
+        assert not TpaOrgAllowlist.objects.filter(pk=entry.id).exists()
+
+    def test_cannot_delete_entry_belonging_to_different_enterprise(self, api_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """A scoped user cannot delete an entry belonging to a different enterprise customer."""
+        other_enterprise = EnterpriseCustomerFactory()
+        entry = TpaOrgAllowlist.objects.create(
+            enterprise_customer=other_enterprise,
+            tpa_org_id=str(uuid4()),
+        )
+
+        scoped_user = UserFactory(username='tpa_svc_del', is_active=True, is_superuser=False, is_staff=False)
+        scoped_user.set_password('password')
+        scoped_user.save()
+        role, _ = SystemWideEnterpriseRole.objects.get_or_create(name=TPA_ORG_ALLOWLIST_ADMIN_ROLE)
+        SystemWideEnterpriseUserRoleAssignment.objects.create(
+            user=scoped_user,
+            role=role,
+            enterprise_customer=enterprise_customer,  # scoped to a DIFFERENT enterprise than the entry
+        )
+
+        api_client.force_authenticate(user=scoped_user)
+
+        url = f'{TPA_ORG_ALLOWLIST_URL}{entry.id}/'
+        response = api_client.delete(url)
+        assert response.status_code == 404
+        assert TpaOrgAllowlist.objects.filter(pk=entry.id).exists()
+
+    def test_cannot_retrieve_entry_belonging_to_different_enterprise(self, api_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """A scoped user cannot retrieve an entry belonging to a different enterprise customer."""
+        other_enterprise = EnterpriseCustomerFactory()
+        entry = TpaOrgAllowlist.objects.create(
+            enterprise_customer=other_enterprise,
+            tpa_org_id=str(uuid4()),
+        )
+
+        scoped_user = UserFactory(username='tpa_svc_get', is_active=True, is_superuser=False, is_staff=False)
+        scoped_user.set_password('password')
+        scoped_user.save()
+        role, _ = SystemWideEnterpriseRole.objects.get_or_create(name=TPA_ORG_ALLOWLIST_ADMIN_ROLE)
+        SystemWideEnterpriseUserRoleAssignment.objects.create(
+            user=scoped_user,
+            role=role,
+            enterprise_customer=enterprise_customer,
+        )
+
+        api_client.force_authenticate(user=scoped_user)
+
+        url = f'{TPA_ORG_ALLOWLIST_URL}{entry.id}/'
+        response = api_client.get(url)
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestTpaOrgAllowlistValidate:
+    """Tests for GET /tpa-org-allowlist/validate/"""
+
+    VALIDATE_URL = f'{TPA_ORG_ALLOWLIST_URL}validate/'
+
+    def test_validate_org_in_allowlist_returns_200(self, authenticated_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """validate/ returns 200 when tpa_org_id is in the allowlist."""
+        tpa_org_id = str(uuid4())
+        TpaOrgAllowlist.objects.create(
+            enterprise_customer=enterprise_customer,
+            tpa_org_id=tpa_org_id,
+        )
+        response = authenticated_client.get(self.VALIDATE_URL, {
+            'enterprise_customer': str(enterprise_customer.uuid),
+            'tpa_org_id': tpa_org_id,
+        })
+        assert response.status_code == 200
+        assert response.data['detail'] == 'Authorised.'
+
+    def test_validate_org_not_in_allowlist_returns_404(self, authenticated_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """validate/ returns 404 when tpa_org_id is not in the allowlist."""
+        response = authenticated_client.get(self.VALIDATE_URL, {
+            'enterprise_customer': str(enterprise_customer.uuid),
+            'tpa_org_id': str(uuid4()),
+        })
+        assert response.status_code == 404
+        assert response.data['detail'] == 'Not found.'
+
+    def test_validate_missing_tpa_org_id_returns_400(self, authenticated_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """validate/ returns 400 when tpa_org_id is missing."""
+        response = authenticated_client.get(self.VALIDATE_URL, {'enterprise_customer': str(enterprise_customer.uuid)})
+        assert response.status_code == 400
+        assert 'tpa_org_id is required' in response.data['detail']
+
+    def test_validate_global_token_without_enterprise_customer_returns_400(self, authenticated_client):  # pylint: disable=redefined-outer-name
+        """validate/ returns 400 when a global-access token omits enterprise_customer."""
+        # admin_user is a superuser — has ALL_ACCESS_CONTEXT, so enterprise_customer is required
+        response = authenticated_client.get(self.VALIDATE_URL, {'tpa_org_id': str(uuid4())})
+        assert response.status_code == 400
+        assert 'enterprise_customer is required for tokens with global access' in response.data['detail']
+
+    def test_validate_global_token_with_invalid_enterprise_customer_returns_400(self, authenticated_client):  # pylint: disable=redefined-outer-name
+        """validate/ returns 400 (not 500) when enterprise_customer is not a valid UUID."""
+        response = authenticated_client.get(
+            self.VALIDATE_URL,
+            {'tpa_org_id': str(uuid4()), 'enterprise_customer': 'not-a-uuid'},
+        )
+        assert response.status_code == 400
+        assert 'not a valid uuid' in response.data['detail'].lower()
+
+    def test_validate_scoped_user_derives_enterprise_from_role_assignment(self, api_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """
+        A service user with a DB role assignment does not need to pass enterprise_customer —
+        the enterprise UUID is derived from their assigned contexts.
+        """
+        scoped_user = UserFactory(username='tpa_svc', is_active=True, is_superuser=False, is_staff=False)
+        scoped_user.set_password('password')
+        scoped_user.save()
+
+        role, _ = SystemWideEnterpriseRole.objects.get_or_create(name=TPA_ORG_ALLOWLIST_ADMIN_ROLE)
+        SystemWideEnterpriseUserRoleAssignment.objects.create(
+            user=scoped_user,
+            role=role,
+            enterprise_customer=enterprise_customer,
+        )
+
+        api_client.force_authenticate(user=scoped_user)
+
+        tpa_org_id = str(uuid4())
+        TpaOrgAllowlist.objects.create(enterprise_customer=enterprise_customer, tpa_org_id=tpa_org_id)
+
+        # No enterprise_customer param — derived from the role assignment
+        response = api_client.get(self.VALIDATE_URL, {'tpa_org_id': tpa_org_id})
+        assert response.status_code == 200
+        assert response.data['detail'] == 'Authorised.'
+
+
+@pytest.mark.django_db
+class TestTpaOrgAllowlistAuthentication:
+    """Tests for unauthenticated and unauthorised access."""
+
+    def test_unauthenticated_request_is_denied(self):
+        """Unauthenticated request to any endpoint is denied."""
+        client = APIClient()
+        response = client.get(TPA_ORG_ALLOWLIST_URL)
+        assert response.status_code in (401, 403)
+
+    def test_user_without_role_is_forbidden(self, api_client, regular_user, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """User authenticated but lacking tpa_org_allowlist_admin role receives 403."""
+        api_client.force_authenticate(user=regular_user)
+        response = api_client.post(
+            TPA_ORG_ALLOWLIST_URL,
+            data={
+                'enterprise_customer': str(enterprise_customer.uuid),
+                'tpa_org_id': str(uuid4()),
+            },
+            format='json',
+        )
+        assert response.status_code == 403


### PR DESCRIPTION
Adds a new `tpa-org-allowlist` API that lets admins manage which third-party auth org IDs are permitted to log in to an enterprise's edX environment.

Access is gated by a new dedicated `tpa_org_allowlist_admin` role (separate from enterprise_admin) so it can be granted narrowly to a service account.
https://github.com/openedx/edx-rbac/pull/430

Includes full how-to docs covering API reference, service account setup (Django admin UI and shell), and Auth0 Action configuration.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
