### PR TITLE
chore: change the cron schedule to run on friday instead of monday

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,7 @@ name: Upgrade Python Requirements
 
 on:
   schedule:
-    - cron: "0 0 * * 1"
+    - cron: "0 0 * * 5"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
**Description:**
Move all the make upgrade Github jobs to Friday instead of Monday.

**Jira:**
[ENT-11931](https://2u-internal.atlassian.net/browse/ENT-11931)

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
