### PR TITLE
fix: skip content metadata items with no catalog metadata.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 **********
 
+0.1.60 – 2026-06-15
+*******************
+
+* fix: skip content metadata items that have no catalog metadata instead of aborting the whole customer export
+
 0.1.59 – 2026-05-27
 *******************
 

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.59'  # pragma: no cover
+__version__ = '0.1.60'  # pragma: no cover

--- a/channel_integrations/integrated_channel/exporters/content_metadata.py
+++ b/channel_integrations/integrated_channel/exporters/content_metadata.py
@@ -462,6 +462,39 @@ class ContentMetadataExporter(Exporter):
         item.content_last_changed = metadata.get('content_last_modified')
         item.save()
 
+    def _build_action_payload(self, items, action, enterprise_customer_catalog, key_to_content_metadata_mapping):
+        """
+        Sanitize metadata for each item under ``action`` and return the resulting transmission payload.
+
+        Items whose content key has no metadata in ``key_to_content_metadata_mapping`` are skipped
+        (and logged) instead of raising, so a single missing key does not abort the whole export.
+        """
+        payload = {}
+        for key, item in items.items():
+            metadata = key_to_content_metadata_mapping.get(key)
+            if metadata is None:
+                self._log_info(
+                    f'Skipping content key {key} for "{action}": it was returned by the catalog diff '
+                    f'but get_content_metadata returned no metadata for it.',
+                    course_or_course_run_key=key,
+                )
+                continue
+            try:
+                self._sanitize_and_set_item_metadata(item, metadata, action)
+            except Exception as exc:
+                self._log_exception(
+                    f'Failed to sanitize and set item metadata for item: {item}, with content key: '
+                    f'{key}, and content metadata: {metadata}, action: {action}. Exception: {exc}'
+                )
+                raise exc
+
+            # Sanity check
+            item.enterprise_customer_catalog_uuid = enterprise_customer_catalog.uuid
+            item.save()
+
+            payload[key] = item
+        return payload
+
     def export(self, **kwargs):
         """
         Export transformed content metadata if there has been an update to the consumer's catalogs
@@ -515,38 +548,12 @@ class ContentMetadataExporter(Exporter):
                 key_to_content_metadata_mapping = {
                     get_content_metadata_item_id(item): item for item in content_metadata_items
                 }
-            for key, item in items_to_create.items():
-                try:
-                    self._sanitize_and_set_item_metadata(item, key_to_content_metadata_mapping[key], IC_CREATE_ACTION)
-                except Exception as exc:
-                    self._log_exception(
-                        f'Failed to sanitize and set item metadata for item: {item}, with content key: '
-                        f'{key}, and content metadata: {key_to_content_metadata_mapping[key]}, action: '
-                        f'{IC_CREATE_ACTION}. Exception: {exc}'
-                    )
-                    raise exc
-
-                # Sanity check
-                item.enterprise_customer_catalog_uuid = enterprise_customer_catalog.uuid
-                item.save()
-
-                create_payload[key] = item
-            for key, item in items_to_update.items():
-                try:
-                    self._sanitize_and_set_item_metadata(item, key_to_content_metadata_mapping[key], IC_UPDATE_ACTION)
-                except Exception as exc:
-                    self._log_exception(
-                        f'Failed to sanitize and set item metadata for item: {item}, with content key: '
-                        f'{key}, and content metadata: {key_to_content_metadata_mapping[key]}, action: '
-                        f'{IC_UPDATE_ACTION}. Exception: {exc}'
-                    )
-                    raise exc
-
-                # Sanity check
-                item.enterprise_customer_catalog_uuid = enterprise_customer_catalog.uuid
-                item.save()
-
-                update_payload[key] = item
+            create_payload.update(self._build_action_payload(
+                items_to_create, IC_CREATE_ACTION, enterprise_customer_catalog, key_to_content_metadata_mapping,
+            ))
+            update_payload.update(self._build_action_payload(
+                items_to_update, IC_UPDATE_ACTION, enterprise_customer_catalog, key_to_content_metadata_mapping,
+            ))
             for key, item in items_to_delete.items():
                 metadata = self._apply_delete_transformation(item.channel_metadata)
                 item.channel_metadata = metadata

--- a/tests/test_channel_integrations/test_integrated_channel/test_exporters/test_content_metadata.py
+++ b/tests/test_channel_integrations/test_integrated_channel/test_exporters/test_content_metadata.py
@@ -292,6 +292,64 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
 
     @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_content_metadata')
     @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_catalog_diff')
+    def test_exporter_skips_create_items_missing_catalog_metadata(
+        self,
+        mock_get_catalog_diff,
+        mock_get_content_metadata,
+    ):
+        """
+        A create key returned by the catalog diff but absent from ``get_content_metadata`` is skipped
+        (logged, not fatal); other items still export.
+        """
+        good_key = 'GoodX+Create'
+        missing_key = 'MissingX+Create'
+        mock_get_catalog_diff.return_value = (
+            [{'content_key': good_key, 'date_updated': datetime.datetime.now()},
+             {'content_key': missing_key, 'date_updated': datetime.datetime.now()}],
+            [],
+            [],
+        )
+        # Metadata comes back only for the good key; the missing key has none.
+        good_metadata = get_fake_content_metadata()[:1]
+        good_metadata[0]['key'] = good_key
+        mock_get_content_metadata.return_value = good_metadata
+
+        create_payload, _, __ = ContentMetadataExporter('fake-user', self.config).export()
+
+        assert good_key in create_payload
+        assert missing_key not in create_payload
+
+    @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_content_metadata')
+    @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_catalog_diff')
+    def test_exporter_skips_update_items_missing_catalog_metadata(
+        self,
+        mock_get_catalog_diff,
+        mock_get_content_metadata,
+    ):
+        """
+        An update key matched by the catalog diff but absent from ``get_content_metadata`` is skipped
+        instead of raising ``KeyError`` and aborting the whole export (the prod CEPAL/General Mills case).
+        """
+        existing = ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.enterprise_customer_catalog.enterprise_customer,
+            enterprise_customer_catalog_uuid=self.enterprise_customer_catalog.uuid,
+            integrated_channel_code=self.config.channel_code(),
+            plugin_configuration_id=self.config.id,
+            remote_created_at=datetime.datetime.utcnow(),
+            content_last_changed=None,
+        )
+        # Catalog diff matches it for update, but the metadata endpoint returns nothing for it.
+        mock_get_catalog_diff.return_value = (
+            [], [], [{'content_key': existing.content_id, 'date_updated': datetime.datetime.now()}]
+        )
+        mock_get_content_metadata.return_value = []
+
+        _, update_payload, __ = ContentMetadataExporter('fake-user', self.config).export()
+
+        assert not update_payload
+
+    @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_content_metadata')
+    @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_catalog_diff')
     def test_exporter_considers_failed_updates_as_existing_content(
         self,
         mock_get_catalog_diff,


### PR DESCRIPTION
Fixes: [ENT-11916](https://2u-internal.atlassian.net/browse/ENT-11916)

 `get_content_metadata` may not return a key the catalog diff included; .get() and skip it (logged) rather than KeyError-ing the whole customer's export.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [x] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
