### PR TITLE
refactor: configure integrated-channels structured logging in AppConfig.ready()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 **********
 
+0.1.61 – 2026-06-22
+*******************
+
+* refactor: configure Integrated Channels structured logging from ``AppConfig.ready()`` instead of edx-platform's shared ``logsettings.py``
+
 0.1.60 – 2026-06-15
 *******************
 

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.60'  # pragma: no cover
+__version__ = '0.1.61'  # pragma: no cover

--- a/channel_integrations/integrated_channel/apps.py
+++ b/channel_integrations/integrated_channel/apps.py
@@ -15,7 +15,10 @@ class IntegratedChannelConfig(AppConfig):
 
     def ready(self):
         """
-        Register signal handlers.
+        Register signal handlers and configure structured logging.
         """
         # pylint: disable=import-outside-toplevel, unused-import
         from channel_integrations.integrated_channel import signals
+        from channel_integrations.integrated_channel.structured_logging import configure_structured_logging
+
+        configure_structured_logging()

--- a/channel_integrations/integrated_channel/structured_logging.py
+++ b/channel_integrations/integrated_channel/structured_logging.py
@@ -14,6 +14,11 @@ from django.conf import settings
 
 SERVICE_NAME = 'integrated_channels'
 
+# Root logger namespace for the integrated-channels package. Every
+# ``logging.getLogger(__name__)`` call inside channel_integrations is a child of
+# this logger, so configuring it here covers the whole package.
+CHANNEL_INTEGRATIONS_LOGGER = 'channel_integrations'
+
 LOG_STATUS_BY_LEVEL = {
     logging.CRITICAL: 'critical',
     logging.ERROR: 'error',
@@ -401,3 +406,32 @@ def build_datadog_log_record(record):
     }
     log_record.update(fields)
     return log_record
+
+
+def configure_structured_logging():
+    """
+    Route the integrated-channels logger through a JSON stderr handler when
+    ``INTEGRATED_CHANNELS_JSON_LOGGING`` is enabled.
+
+    Keeps integrated-channels logging configuration inside the library instead of
+    edx-platform's shared ``openedx/core/lib/logsettings.py``. When the flag is off
+    this is a no-op and records propagate to the root logger exactly as before; when
+    it is on, ``channel_integrations`` records are emitted as Datadog-ready JSON on
+    stderr and no longer propagate to the root console handler.
+    """
+    if not is_json_logging_enabled():
+        return
+
+    logger = logging.getLogger(CHANNEL_INTEGRATIONS_LOGGER)
+
+    # Idempotent: AppConfig.ready() can run more than once (e.g. across test reloads).
+    if any(isinstance(handler.formatter, JsonChannelFormatter) for handler in logger.handlers):
+        return
+
+    json_handler = logging.StreamHandler()  # defaults to sys.stderr
+    json_handler.setFormatter(JsonChannelFormatter())
+    logger.addHandler(json_handler)
+
+    logger.setLevel(logging.INFO)
+    # Stop propagation so records aren't also emitted by the root console handler.
+    logger.propagate = False

--- a/tests/test_channel_integrations/test_integrated_channel/test_structured_logging.py
+++ b/tests/test_channel_integrations/test_integrated_channel/test_structured_logging.py
@@ -364,3 +364,66 @@ class TestStructuredLogging(unittest.TestCase):
         assert data['integrated_channel.customer_uuid'] == '5d566680-12a8-4b85-89d8-d9eacbf0f9eb'
         assert data['integrated_channel.user_id'] == 57164631
         assert data['integrated_channel.course_key'] == 'HP+HPGG02.en'
+
+    def _reset_channel_logger(self):
+        """
+        Isolate the shared ``channel_integrations`` logger and restore it after the test.
+        """
+        logger = logging.getLogger('channel_integrations')
+        original_handlers = logger.handlers[:]
+        original_propagate = logger.propagate
+        original_level = logger.level
+
+        def restore():
+            logger.handlers = original_handlers
+            logger.propagate = original_propagate
+            logger.setLevel(original_level)
+
+        self.addCleanup(restore)
+        logger.handlers = []
+        logger.propagate = True
+        logger.setLevel(logging.NOTSET)
+        return logger
+
+    @override_settings(INTEGRATED_CHANNELS_JSON_LOGGING=True)
+    def test_configure_structured_logging_wires_channel_logger_when_enabled(self):
+        logger = self._reset_channel_logger()
+
+        structured_logging.configure_structured_logging()
+
+        json_handlers = [h for h in logger.handlers if isinstance(h.formatter, JsonChannelFormatter)]
+        assert len(json_handlers) == 1
+        assert logger.level == logging.INFO
+        assert logger.propagate is False
+
+        # ready() can run more than once; a second call must not stack another handler.
+        structured_logging.configure_structured_logging()
+        json_handlers = [h for h in logger.handlers if isinstance(h.formatter, JsonChannelFormatter)]
+        assert len(json_handlers) == 1
+
+    def test_configure_structured_logging_noop_when_disabled(self):
+        # With the flag off the logger must be left untouched so records keep
+        # propagating to the root logger (this is what keeps pytest's caplog working).
+        logger = self._reset_channel_logger()
+
+        structured_logging.configure_structured_logging()
+
+        assert not any(isinstance(h.formatter, JsonChannelFormatter) for h in logger.handlers)
+        assert logger.propagate is True
+
+    @override_settings(INTEGRATED_CHANNELS_JSON_LOGGING=True)
+    @mock.patch('channel_integrations.integrated_channel.structured_logging.get_datadog_trace_id')
+    def test_configure_structured_logging_emits_json_when_enabled(self, mock_get_trace_id):
+        mock_get_trace_id.return_value = None
+        logger = self._reset_channel_logger()
+        structured_logging.configure_structured_logging()
+
+        handler = next(h for h in logger.handlers if isinstance(h.formatter, JsonChannelFormatter))
+        stream = io.StringIO()
+        handler.stream = stream
+
+        logging.getLogger('channel_integrations.test_enabled').error('boom')
+
+        data = json.loads(stream.getvalue())
+        assert data['message'] == 'boom'
+        assert data['status'] == 'error'


### PR DESCRIPTION
Configure integrated-channels structured logging from `AppConfig.ready()` instead of edx-platform's `logsettings.py`.
`configure_structured_logging()` attaches a JSON-capable stderr handler to the `channel_integrations` logger, gated by `INTEGRATED_CHANNELS_JSON_LOGGING` (falls back to legacy text when off).