### PR TITLE
fix: update Blackboard content payload formatting (ENT-12020)

### DIFF
--- a/channel_integrations/blackboard/exporters/content_metadata.py
+++ b/channel_integrations/blackboard/exporters/content_metadata.py
@@ -73,7 +73,8 @@ class BlackboardContentMetadataExporter(ContentMetadataExporter):
         title = content_metadata_item.get('title', None)
         return {
             'title': BLACKBOARD_COURSE_CONTENT_NAME,
-            'availability': 'Yes',
+            # Blackboard content endpoints expect an availability object.
+            'availability': {'available': 'Yes'},
             'contentHandler': {
                 'id': 'resource/x-bb-document',
             },

--- a/tests/test_channel_integrations/test_blackboard/test_exporters/test_content_metadata.py
+++ b/tests/test_channel_integrations/test_blackboard/test_exporters/test_content_metadata.py
@@ -88,7 +88,7 @@ class TestBlackboardContentMetadataExporter(unittest.TestCase, EnterpriseMockMix
         description = exporter.transform_course_child_content_metadata(content_metadata_item)
         expected_description = {
             'title': content_metadata_item.get('title'),
-            'availability': 'Yes',
+            'availability': {'available': 'Yes'},
             'contentHandler': {
                 'id': 'resource/x-bb-document',
             },


### PR DESCRIPTION
 **Title**

Implemented a targeted Blackboard content metadata formatting fix to align with the latest Blackboard Learn API schema and validated the changes with unit tests.

 **Summary** 

Updated the Blackboard child content payload formatting in:

* channel_integrations/blackboard/exporters/content_metadata.py

### **Payload Change**

Changed the availability field from:


availability: "Yes"


to:


availability: {"available": "Yes"}


Updated the corresponding unit test in:

* tests/test_channel_integrations/test_blackboard/test_exporters/test_content_metadata.py

The expected value was modified to validate the new object-based `availability` format.

**Change**

Blackboard Learn's content APIs expect the `availability` field to be provided as an object rather than a plain string. The previous payload format no longer conforms to the current API schema and can result in content metadata transmission failures.

This change addresses the formatting issue identified in **ENT-7604** and **ENT-12020** while keeping the implementation minimal and scoped to Blackboard content metadata formatting.

** Validation**

Executed:

tests/test_channel_integrations/test_blackboard/test_exporters/test_content_metadata.py

**Result:** 3 tests passed.

** Scope**

* Updated Blackboard content metadata payload formatting.
* Updated unit tests to reflect the new payload schema.
* No changes were made outside the Blackboard content metadata exporter and its associated tests.

