### PR TITLE
feat: implemented course hours fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 **********
 
+0.1.63 – 2026-07-20
+*******************
+
+* fix: implemented course hours field
+
 0.1.62 – 2026-07-07
 *******************
 

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.62'  # pragma: no cover
+__version__ = '0.1.63'  # pragma: no cover

--- a/channel_integrations/sap_success_factors/exporters/content_metadata.py
+++ b/channel_integrations/sap_success_factors/exporters/content_metadata.py
@@ -215,7 +215,11 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         """
         Return estimated course run hours as a float, defaulting to ``0.0``.
         """
-        course_run = get_advertised_or_closest_course_run(content_metadata_item)
+        if content_metadata_item.get('content_type') == 'courserun':
+            course_run = content_metadata_item
+        else:
+            course_run = get_advertised_or_closest_course_run(content_metadata_item)
+
         if not course_run:
             return 0.0
 
@@ -233,9 +237,7 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
 
     def transform_credit_hours(self, content_metadata_item):
         """Return the credit hours for the content item, sourced from estimated_hours."""
-        if not self.enterprise_configuration.transmit_total_hours:
-            return 0.0
-        return self._get_estimated_hours(content_metadata_item)
+        return self.transform_total_hours(content_metadata_item)
 
     def transform_courserun_title(self, content_metadata_item):
         """

--- a/channel_integrations/sap_success_factors/exporters/content_metadata.py
+++ b/channel_integrations/sap_success_factors/exporters/content_metadata.py
@@ -46,6 +46,8 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         'revisionNumber': 'revision_number',
         'schedule': 'schedule',
         'price': 'price',
+        'totalHours': 'total_hours',
+        'creditHours': 'credit_hours',
     }
 
     def _apply_delete_transformation(self, metadata):
@@ -208,6 +210,32 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
                 "value": price
             }
         ]
+
+    def _get_estimated_hours(self, content_metadata_item):
+        """
+        Return estimated course run hours as a float, defaulting to ``0.0``.
+        """
+        course_run = get_advertised_or_closest_course_run(content_metadata_item)
+        if not course_run:
+            return 0.0
+
+        estimated_hours = course_run.get('estimated_hours') or 0.0
+        try:
+            return float(estimated_hours)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def transform_total_hours(self, content_metadata_item):
+        """Return the total hours for the content item, sourced from estimated_hours."""
+        if not self.enterprise_configuration.transmit_total_hours:
+            return 0.0
+        return self._get_estimated_hours(content_metadata_item)
+
+    def transform_credit_hours(self, content_metadata_item):
+        """Return the credit hours for the content item, sourced from estimated_hours."""
+        if not self.enterprise_configuration.transmit_total_hours:
+            return 0.0
+        return self._get_estimated_hours(content_metadata_item)
 
     def transform_courserun_title(self, content_metadata_item):
         """

--- a/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -307,6 +307,20 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             True,
             0.0,
         ),
+        (
+            {
+                'course_runs': [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'estimated_hours': 'not-a-number',
+                        'start': '2024-01-01T00:00:00Z',
+                        'end': '2024-06-01T00:00:00Z',
+                    },
+                ],
+            },
+            True,
+            0.0,
+        ),
     )
     @ddt.unpack
     def test_transform_total_hours(self, content_metadata_item, transmit_flag, expected):

--- a/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -321,6 +321,18 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             True,
             0.0,
         ),
+        (
+            {
+                'content_type': 'courserun',
+                'estimated_hours': 6.25,
+                'start': '2024-01-01T00:00:00Z',
+                'end': '2024-06-01T00:00:00Z',
+                'availability': 'Current',
+                'status': 'published',
+            },
+            True,
+            6.25,
+        ),
     )
     @ddt.unpack
     def test_transform_total_hours(self, content_metadata_item, transmit_flag, expected):
@@ -357,6 +369,18 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             },
             False,
             0.0,
+        ),
+        (
+            {
+                'content_type': 'courserun',
+                'estimated_hours': 4.5,
+                'start': '2024-01-01T00:00:00Z',
+                'end': '2024-06-01T00:00:00Z',
+                'availability': 'Current',
+                'status': 'published',
+            },
+            True,
+            4.5,
         ),
     )
     @ddt.unpack

--- a/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -226,6 +226,248 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
         ]
 
     @ddt.data(
+        (
+            {
+                'advertised_course_run_uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                'course_runs': [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'estimated_hours': 10.5,
+                        'start': '2024-01-01T00:00:00Z',
+                        'end': '2024-06-01T00:00:00Z',
+                    },
+                    {
+                        'uuid': '28e2d4c2-a020-4959-b461-6f879bbe1391',
+                        'estimated_hours': 5.0,
+                        'start': '2023-01-01T00:00:00Z',
+                        'end': '2023-06-01T00:00:00Z',
+                    },
+                ],
+            },
+            True,
+            10.5,
+        ),
+        (
+            {
+                'course_runs': [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'start': '2024-01-01T00:00:00Z',
+                        'end': '2024-06-01T00:00:00Z',
+                    },
+                ],
+            },
+            True,
+            0.0,
+        ),
+        (
+            {
+                'course_runs': [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'estimated_hours': None,
+                        'start': '2024-01-01T00:00:00Z',
+                        'end': '2024-06-01T00:00:00Z',
+                    },
+                ],
+            },
+            True,
+            0.0,
+        ),
+        (
+            {
+                'course_runs': [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'estimated_hours': 10.5,
+                        'start': '2024-01-01T00:00:00Z',
+                        'end': '2024-06-01T00:00:00Z',
+                    },
+                ],
+            },
+            False,
+            0.0,
+        ),
+        (
+            {'course_runs': []},
+            True,
+            0.0,
+        ),
+        (
+            {
+                'course_runs': [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'estimated_hours': 0.0,
+                        'start': '2024-01-01T00:00:00Z',
+                        'end': '2024-06-01T00:00:00Z',
+                    },
+                ],
+            },
+            True,
+            0.0,
+        ),
+    )
+    @ddt.unpack
+    def test_transform_total_hours(self, content_metadata_item, transmit_flag, expected):
+        self.config.transmit_total_hours = transmit_flag
+        self.config.save()
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_total_hours(content_metadata_item) == expected
+
+    @ddt.data(
+        (
+            {
+                'course_runs': [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'estimated_hours': 8.0,
+                        'start': '2024-01-01T00:00:00Z',
+                        'end': '2024-06-01T00:00:00Z',
+                    },
+                ],
+            },
+            True,
+            8.0,
+        ),
+        (
+            {
+                'course_runs': [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'estimated_hours': 8.0,
+                        'start': '2024-01-01T00:00:00Z',
+                        'end': '2024-06-01T00:00:00Z',
+                    },
+                ],
+            },
+            False,
+            0.0,
+        ),
+    )
+    @ddt.unpack
+    def test_transform_credit_hours(self, content_metadata_item, transmit_flag, expected):
+        self.config.transmit_total_hours = transmit_flag
+        self.config.save()
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_credit_hours(content_metadata_item) == expected
+
+    def test_transform_total_hours_uses_advertised_course_run(self):
+        self.config.transmit_total_hours = True
+        self.config.save()
+        content_metadata_item = {
+            'advertised_course_run_uuid': '28e2d4c2-a020-4959-b461-6f879bbe1391',
+            'course_runs': [
+                {
+                    'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                    'estimated_hours': 5.0,
+                    'start': '2023-01-01T00:00:00Z',
+                    'end': '2023-06-01T00:00:00Z',
+                },
+                {
+                    'uuid': '28e2d4c2-a020-4959-b461-6f879bbe1391',
+                    'estimated_hours': 12.0,
+                    'start': '2024-01-01T00:00:00Z',
+                    'end': '2024-06-01T00:00:00Z',
+                },
+            ],
+        }
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_total_hours(content_metadata_item) == 12.0
+
+    def test_total_hours_and_credit_hours_are_equal(self):
+        self.config.transmit_total_hours = True
+        self.config.save()
+        content_metadata_item = {
+            'course_runs': [
+                {
+                    'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                    'estimated_hours': 7.5,
+                    'start': '2024-01-01T00:00:00Z',
+                    'end': '2024-06-01T00:00:00Z',
+                },
+            ],
+        }
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+        total_hours = exporter.transform_total_hours(content_metadata_item)
+        credit_hours = exporter.transform_credit_hours(content_metadata_item)
+        assert total_hours == credit_hours == 7.5
+
+    def test_transform_item_includes_hour_fields_when_enabled(self):
+        self.config.transmit_total_hours = True
+        self.config.save()
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+        content_metadata_item = {
+            'aggregation_key': 'course:edX+DemoX',
+            'content_type': 'course',
+            'full_description': 'A demo course.',
+            'key': 'edX+DemoX',
+            'title': 'edX Demonstration Course',
+            'course_runs': [
+                {
+                    'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                    'key': 'course-v1:edX+DemoX+1T2024',
+                    'title': 'edX Demonstration Course',
+                    'short_description': 'A demo.',
+                    'availability': 'Current',
+                    'pacing_type': 'self_paced',
+                    'start': '2024-01-01T00:00:00Z',
+                    'end': '2024-12-31T00:00:00Z',
+                    'estimated_hours': 15.0,
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'seats': [],
+                },
+            ],
+            'advertised_course_run_uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+            'uuid': 'bbbf059e-b9fb-4ad7-a53e-4c6f85f47f4e',
+            'enrollment_url': 'https://courses.edx.org/enroll',
+        }
+        # pylint: disable=protected-access
+        transformed = exporter._transform_item(content_metadata_item, action='create')
+        assert 'totalHours' in transformed
+        assert 'creditHours' in transformed
+        assert transformed['totalHours'] == 15.0
+        assert transformed['creditHours'] == 15.0
+
+    def test_transform_item_includes_zero_hours_when_disabled(self):
+        self.config.transmit_total_hours = False
+        self.config.save()
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+        content_metadata_item = {
+            'aggregation_key': 'course:edX+DemoX',
+            'content_type': 'course',
+            'full_description': 'A demo course.',
+            'key': 'edX+DemoX',
+            'title': 'edX Demonstration Course',
+            'course_runs': [
+                {
+                    'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                    'key': 'course-v1:edX+DemoX+1T2024',
+                    'title': 'edX Demonstration Course',
+                    'short_description': 'A demo.',
+                    'availability': 'Current',
+                    'pacing_type': 'self_paced',
+                    'start': '2024-01-01T00:00:00Z',
+                    'end': '2024-12-31T00:00:00Z',
+                    'estimated_hours': 15.0,
+                    'status': 'published',
+                    'is_enrollable': True,
+                    'is_marketable': True,
+                    'seats': [],
+                },
+            ],
+            'advertised_course_run_uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+            'uuid': 'bbbf059e-b9fb-4ad7-a53e-4c6f85f47f4e',
+            'enrollment_url': 'https://courses.edx.org/enroll',
+        }
+        # pylint: disable=protected-access
+        transformed = exporter._transform_item(content_metadata_item, action='create')
+        assert transformed['totalHours'] == 0.0
+        assert transformed['creditHours'] == 0.0
+
+    @ddt.data(
         {
             'start': '2013-02-05T05:00:00Z',
             'pacing_type': 'instructor_paced',


### PR DESCRIPTION
**Description**

Adds totalHours and creditHours fields to the SAP SuccessFactors content metadata (catalog discovery) payload, gated behind the existing transmit_total_hours flag on SAPSuccessFactorsEnterpriseCustomerConfiguration. Both fields are sourced from estimated_hours on the advertised (or closest) course run, mirroring the existing learner completion flow (ENT-10588). When the flag is disabled, both fields default to 0.0. No new models, migrations, or configuration flags are introduced.

**Changes**

Added 'totalHours': 'total_hours' and 'creditHours': 'credit_hours' to DATA_TRANSFORM_MAPPING, implemented transform_total_hours() and transform_credit_hours() methods, and extracted a shared _get_estimated_hours() private helper to avoid duplication. The helper uses get_advertised_or_closest_course_run() (already imported) to extract the raw float estimated_hours from the best course run, defaulting to 0.0 when missing or None. Both transforms are gated by self.enterprise_configuration.transmit_total_hours — returning 0.0 when the flag is off.

**Tests**

Unit tests: Parameterized coverage across all branches — flag on/off, missing/None/zero estimated_hours, empty course runs, advertised run priority, and _transform_item integration. All passing.

Mock output verification: Ran a proof-of-work script that instantiates the actual exporter with factory data and prints the full transformed JSON payload, confirming totalHours/creditHours appear correctly (15.0 when flag on, 0.0 when off, 0.0 on missing data). Screenshots below.

<img width="517" height="469" alt="image (13)" src="https://github.com/user-attachments/assets/f399ee1f-55a4-4cd7-84d7-5a19880c45c6" />
<img width="368" height="484" alt="image (14)" src="https://github.com/user-attachments/assets/b811cd87-4316-44ed-93a4-8e4bd28cf81c" />
<img width="400" height="494" alt="image (15)" src="https://github.com/user-attachments/assets/d56a5cdb-a5e9-4bfd-a964-31eb73de3432" />
