### PR TITLE
docs: fix CHANGELOG formatting to enable pypi publish

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,14 +10,19 @@ Change Log
    This project adheres to Semantic Versioning (https://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
+
 Unreleased
 **********
+
+0.1.65 – 2026-07-22
+*******************
+
+* docs: fix CHANGELOG formatting to enable pypi publish
 
 0.1.64 – 2026-07-22
 *******************
 
 * feat: make Blackboard transmission chunk size editable in Django Admin
-
 
 0.1.63 – 2026-07-20
 *******************

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.64'  # pragma: no cover
+__version__ = '0.1.65'  # pragma: no cover


### PR DESCRIPTION
[PR 182 ](https://github.com/openedx/enterprise-integrated-channels/pull/182/changes) broke the CHANGELOG formatting by deleting the blank line before `Unreleased`. That caused the publish to PyPi action to fail: https://github.com/openedx/enterprise-integrated-channels/actions/runs/30270375097

This PR adds that line back and bumps the version so we can draft and publish a new release.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
