### PR TITLE
fix: Org ID API perform create validation

### DIFF
--- a/channel_integrations/api/v1/tpa_org_allowlist/views.py
+++ b/channel_integrations/api/v1/tpa_org_allowlist/views.py
@@ -6,6 +6,7 @@ from uuid import UUID
 import crum
 from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from edx_rbac.utils import has_access_to_all
@@ -64,6 +65,22 @@ class TpaOrgAllowlistViewSet(
         if not has_access_to_all(self.accessible_contexts):
             qs = qs.filter(enterprise_customer_id__in=self.accessible_contexts)
         return qs
+
+    def perform_create(self, serializer):
+        """
+        Reject attempts to create an entry for an enterprise customer outside the
+        caller's accessible contexts. Without this, any caller holding the
+        allowlist-admin role for *some* enterprise could target an arbitrary
+        `enterprise_customer` in the request body and grant SSO access into an
+        enterprise they have no assignment for.
+        """
+        enterprise_customer = serializer.validated_data['enterprise_customer']
+        if (
+            not has_access_to_all(self.accessible_contexts)
+            and str(enterprise_customer.pk) not in self.accessible_contexts
+        ):
+            raise PermissionDenied('You do not have access to manage the allowlist for this enterprise customer.')
+        serializer.save()
 
     @action(detail=False, methods=['get'], url_path='validate')
     def validate(self, request):

--- a/tests/test_channel_integrations/test_integrated_channel/test_tpa_org_allowlist.py
+++ b/tests/test_channel_integrations/test_integrated_channel/test_tpa_org_allowlist.py
@@ -87,6 +87,30 @@ class TestTpaOrgAllowlistCreate:
         response = authenticated_client.post(TPA_ORG_ALLOWLIST_URL, data=payload, format='json')
         assert response.status_code == 400
 
+    def test_cannot_create_entry_for_different_enterprise(self, api_client, enterprise_customer):  # pylint: disable=redefined-outer-name
+        """A scoped user cannot create an entry for an enterprise customer they aren't assigned to."""
+        other_enterprise = EnterpriseCustomerFactory()
+
+        scoped_user = UserFactory(username='tpa_svc_create', is_active=True, is_superuser=False, is_staff=False)
+        scoped_user.set_password('password')
+        scoped_user.save()
+        role, _ = SystemWideEnterpriseRole.objects.get_or_create(name=TPA_ORG_ALLOWLIST_ADMIN_ROLE)
+        SystemWideEnterpriseUserRoleAssignment.objects.create(
+            user=scoped_user,
+            role=role,
+            enterprise_customer=enterprise_customer,  # scoped to a DIFFERENT enterprise than the target
+        )
+
+        api_client.force_authenticate(user=scoped_user)
+
+        payload = {
+            'enterprise_customer': str(other_enterprise.uuid),
+            'tpa_org_id': str(uuid4()),
+        }
+        response = api_client.post(TPA_ORG_ALLOWLIST_URL, data=payload, format='json')
+        assert response.status_code == 403
+        assert not TpaOrgAllowlist.objects.filter(enterprise_customer=other_enterprise).exists()
+
 
 @pytest.mark.django_db
 class TestTpaOrgAllowlistList:


### PR DESCRIPTION
## Summary

`POST /channel_integrations/api/v1/tpa-org-allowlist/` had no server-side check that the `enterprise_customer` in the request body matched the caller's assigned enterprise. `retrieve`/`list`/`destroy` were already scoped to the caller's `accessible_contexts`, but `create` was not, and `enterprise_customer` is a writable field on `TpaOrgAllowlistSerializer`.

Net effect: any user holding the `tpa_org_allowlist_admin` role for enterprise A could `POST` a payload targeting an arbitrary `enterprise_customer` (enterprise B) and add an org ID to B's SSO allowlist — despite having no role assignment for B. Since `validate` is what Auth0 calls at login time, this was a privilege-escalation path into another customer's environment.

Confirmed there was no other guard (model constraint, serializer validator, DRF default) blocking this: temporarily removing the new check and re-running the test suite reproduced a `201` (entry created) where a `403` is expected.

## Changes

- Add `TpaOrgAllowlistViewSet.perform_create()` to reject (403) create requests where `enterprise_customer` isn't in the caller's `accessible_contexts`, mirroring the scoping already applied to `get_queryset()`.
- Add `test_cannot_create_entry_for_different_enterprise` covering the previously-missing case.

## Test plan

- [x] `pytest tests/test_channel_integrations/test_integrated_channel/test_tpa_org_allowlist.py` — 15 passed
- [x] Verified the new test fails (`201` instead of `403`) with `perform_create` removed, confirming no other layer enforced this
