### PR TITLE
fix: omit totalHours/creditHours from SAP SF payload when transmit flag is off

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 **********
 
+0.1.66 – 2026-08-04
+*******************
+
+* fix: add override method to omit hours fields when disabled
+
 0.1.65 – 2026-07-22
 *******************
 

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.65'  # pragma: no cover
+__version__ = '0.1.66'  # pragma: no cover

--- a/channel_integrations/sap_success_factors/exporters/content_metadata.py
+++ b/channel_integrations/sap_success_factors/exporters/content_metadata.py
@@ -50,8 +50,17 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         'creditHours': 'credit_hours',
     }
 
-    # Omit keys whose transformer returns None (e.g. hour fields when flag is off)
-    SKIP_KEY_IF_NONE = True
+    def _transform_item(self, content_metadata_item, action):
+        """
+        Transform the content metadata item and omit hours fields when disabled.
+        """
+        transformed_item = super()._transform_item(content_metadata_item, action)
+
+        if not self.enterprise_configuration.transmit_total_hours:
+            transformed_item.pop('totalHours', None)
+            transformed_item.pop('creditHours', None)
+
+        return transformed_item
 
     def _apply_delete_transformation(self, metadata):
         """
@@ -235,7 +244,7 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
     def transform_total_hours(self, content_metadata_item):
         """Return the total hours for the content item, sourced from estimated_hours."""
         if not self.enterprise_configuration.transmit_total_hours:
-            return None
+            return 0.0
         return self._get_estimated_hours(content_metadata_item)
 
     def transform_credit_hours(self, content_metadata_item):

--- a/channel_integrations/sap_success_factors/exporters/content_metadata.py
+++ b/channel_integrations/sap_success_factors/exporters/content_metadata.py
@@ -50,6 +50,9 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         'creditHours': 'credit_hours',
     }
 
+    # Omit keys whose transformer returns None (e.g. hour fields when flag is off)
+    SKIP_KEY_IF_NONE = True
+
     def _apply_delete_transformation(self, metadata):
         """
         Specific transformations required for "deleting" a course on a SAP external service.
@@ -232,7 +235,7 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
     def transform_total_hours(self, content_metadata_item):
         """Return the total hours for the content item, sourced from estimated_hours."""
         if not self.enterprise_configuration.transmit_total_hours:
-            return 0.0
+            return None
         return self._get_estimated_hours(content_metadata_item)
 
     def transform_credit_hours(self, content_metadata_item):

--- a/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -286,7 +286,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                 ],
             },
             False,
-            0.0,
+            None,
         ),
         (
             {'course_runs': []},
@@ -368,7 +368,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                 ],
             },
             False,
-            0.0,
+            None,
         ),
         (
             {
@@ -469,7 +469,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
         assert transformed['totalHours'] == 15.0
         assert transformed['creditHours'] == 15.0
 
-    def test_transform_item_includes_zero_hours_when_disabled(self):
+    def test_transform_item_omits_hour_fields_when_disabled(self):
         self.config.transmit_total_hours = False
         self.config.save()
         exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
@@ -502,8 +502,8 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
         }
         # pylint: disable=protected-access
         transformed = exporter._transform_item(content_metadata_item, action='create')
-        assert transformed['totalHours'] == 0.0
-        assert transformed['creditHours'] == 0.0
+        assert 'totalHours' not in transformed
+        assert 'creditHours' not in transformed
 
     @ddt.data(
         {

--- a/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_channel_integrations/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -3,6 +3,7 @@ Tests for SAPSF content metadata exporters.
 """
 
 import unittest
+from unittest import mock
 
 import ddt
 import responses
@@ -286,7 +287,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                 ],
             },
             False,
-            None,
+            0.0,
         ),
         (
             {'course_runs': []},
@@ -368,7 +369,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                 ],
             },
             False,
-            None,
+            0.0,
         ),
         (
             {
@@ -451,7 +452,6 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                     'pacing_type': 'self_paced',
                     'start': '2024-01-01T00:00:00Z',
                     'end': '2024-12-31T00:00:00Z',
-                    'estimated_hours': 15.0,
                     'status': 'published',
                     'is_enrollable': True,
                     'is_marketable': True,
@@ -466,8 +466,8 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
         transformed = exporter._transform_item(content_metadata_item, action='create')
         assert 'totalHours' in transformed
         assert 'creditHours' in transformed
-        assert transformed['totalHours'] == 15.0
-        assert transformed['creditHours'] == 15.0
+        assert transformed['totalHours'] == 0.0
+        assert transformed['creditHours'] == 0.0
 
     def test_transform_item_omits_hour_fields_when_disabled(self):
         self.config.transmit_total_hours = False
@@ -504,6 +504,48 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
         transformed = exporter._transform_item(content_metadata_item, action='create')
         assert 'totalHours' not in transformed
         assert 'creditHours' not in transformed
+
+    @ddt.data(
+        (True, True),
+        (False, False),
+    )
+    @ddt.unpack
+    def test_transform_item_removes_only_hour_fields_based_on_transmit_flag(self, transmit_flag, expect_hours):
+        self.config.transmit_total_hours = transmit_flag
+        self.config.save()
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+
+        content_metadata_item = {'content_type': 'course'}
+        super_transformed = {
+            'courseID': 'edX+DemoX',
+            'thumbnailURI': 'https://example.com/image.jpg',
+            'totalHours': 0.0,
+            'creditHours': 0.0,
+            'status': 'ACTIVE',
+        }
+
+        with mock.patch(
+            (
+                'channel_integrations.integrated_channel.exporters.content_metadata.'
+                'ContentMetadataExporter._transform_item'
+            ),
+            return_value=super_transformed.copy(),
+        ) as mock_super_transform:
+            # pylint: disable=protected-access
+            transformed = exporter._transform_item(content_metadata_item, action='create')
+
+        mock_super_transform.assert_called_once_with(content_metadata_item, 'create')
+
+        if expect_hours:
+            assert transformed['totalHours'] == 0.0
+            assert transformed['creditHours'] == 0.0
+        else:
+            assert 'totalHours' not in transformed
+            assert 'creditHours' not in transformed
+
+        assert transformed['thumbnailURI'] == 'https://example.com/image.jpg'
+        assert transformed['courseID'] == 'edX+DemoX'
+        assert transformed['status'] == 'ACTIVE'
 
     @ddt.data(
         {


### PR DESCRIPTION
**Description**
Fixes regression introduced in ENT-11870 where totalHours and creditHours were sent to all SAP SuccessFactors customers regardless of the transmit_total_hours flag. Customers like Iochpe-Maxion whose SAP OData schema doesn't recognize these properties were getting HTTP 400 errors. This change leverages the existing SKIP_KEY_IF_NONE pattern to completely omit the keys when the flag is disabled, rather than sending 0.0.

**Changes**
channel_integrations/sap_success_factors/exporters/content_metadata.py

Added SKIP_KEY_IF_NONE = True class attribute (same pattern used by Canvas/Moodle exporters)

transform_total_hours now returns None when transmit_total_hours=False, causing base _transform_item to skip the keys entirely

**Tests**

Updated flag=False ddt cases to expect None instead of 0.0

Renamed integration test to test_transform_item_omits_hour_fields_when_disabled and asserts keys are absent from transformed payload