### PR TITLE
feat: migrate CSOD learner data transmission to the Transcript API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 **********
 
+0.1.66 – 2026-08-04
+*******************
+
+* feat: migrate Cornerstone learner data transmission from the launch-time completion callback to Cornerstone's
+  Transcript API, authenticated with OAuth client credentials instead of the learner's session token; opt-in per
+  customer via new encrypted ``client_id`` / ``client_secret`` config fields
+
 0.1.65 – 2026-07-22
 *******************
 

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.65'  # pragma: no cover
+__version__ = '0.1.66'  # pragma: no cover

--- a/channel_integrations/api/v1/cornerstone/serializers.py
+++ b/channel_integrations/api/v1/cornerstone/serializers.py
@@ -1,6 +1,8 @@
 """
     Serializer for Cornerstone configuration.
 """
+from rest_framework import serializers
+
 from channel_integrations.api.serializers import EnterpriseCustomerPluginConfigSerializer
 from channel_integrations.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
 
@@ -10,7 +12,43 @@ class CornerstoneConfigSerializer(EnterpriseCustomerPluginConfigSerializer):
         model = CornerstoneEnterpriseCustomerConfiguration
         extra_fields = (
             'cornerstone_base_url',
+            'client_id',
+            'client_secret',
             'session_token',
             'session_token_modified'
         )
         fields = EnterpriseCustomerPluginConfigSerializer.Meta.fields + extra_fields
+
+    client_id = serializers.CharField(
+        required=False, allow_blank=False, read_only=False
+    )
+    client_secret = serializers.CharField(
+        required=False, allow_blank=False, read_only=False
+    )
+
+    def _handle_credentials(self, instance, client_id=None, client_secret=None):
+        """
+        Helper to update credentials consistently.
+        """
+        if client_id is not None:
+            instance.encrypted_client_id = client_id
+        if client_secret is not None:
+            instance.encrypted_client_secret = client_secret
+
+    def create(self, validated_data):
+        client_id = validated_data.pop("client_id", None)
+        client_secret = validated_data.pop("client_secret", None)
+
+        instance = super().create(validated_data)
+        self._handle_credentials(instance, client_id, client_secret)
+        instance.save()
+        return instance
+
+    def update(self, instance, validated_data):
+        client_id = validated_data.pop("client_id", None)
+        client_secret = validated_data.pop("client_secret", None)
+
+        instance = super().update(instance, validated_data)
+        self._handle_credentials(instance, client_id, client_secret)
+        instance.save()
+        return instance

--- a/channel_integrations/cornerstone/admin/__init__.py
+++ b/channel_integrations/cornerstone/admin/__init__.py
@@ -42,6 +42,7 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin
         "enterprise_customer_name",
         "active",
         "cornerstone_base_url",
+        "oauth_configured",
     )
 
     readonly_fields = (
@@ -70,6 +71,18 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin
                 being rendered with this admin form.
         """
         return obj.enterprise_customer.name
+
+    @admin.display(boolean=True, description="OAuth configured")
+    def oauth_configured(self, obj):
+        """
+        Returns: whether completions for this customer are authenticated with OAuth rather than
+        the learner's launch-time session token.
+
+        Args:
+            obj: The instance of CornerstoneEnterpriseCustomerConfiguration
+                being rendered with this admin form.
+        """
+        return obj.uses_oauth_completion_auth
 
     @admin.action(
         description="Force content metadata transmission for this Enterprise Customer"

--- a/channel_integrations/cornerstone/client.py
+++ b/channel_integrations/cornerstone/client.py
@@ -6,13 +6,16 @@ import base64
 import json
 import logging
 import time
+from urllib.parse import urljoin
 
 import requests
 from django.apps import apps
+from django.conf import settings
 
 from channel_integrations.cornerstone.utils import get_or_create_key_pair
+from channel_integrations.exceptions import ClientError
 from channel_integrations.integrated_channel.client import IntegratedChannelApiClient
-from channel_integrations.utils import generate_formatted_log
+from channel_integrations.utils import generate_formatted_log, refresh_session_if_expired
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,6 +27,23 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
     Specifically, this class supports obtaining access tokens
     and posting user's course completion status to progress endpoints.
     """
+
+    # Fallback used when CornerstoneGlobalConfiguration.oauth_api_path is not set.
+    DEFAULT_OAUTH_API_PATH = '/services/api/oauth2/token'
+
+    # Cornerstone's Transcript API endpoint for marking a learner's transcript complete.
+    TRANSCRIPT_COMPLETE_API_PATH = getattr(
+        settings,
+        'ENTERPRISE_CORNERSTONE_TRANSCRIPT_COMPLETE_PATH',
+        '/services/api/v1/transcripts/complete',
+    )
+
+    # Scope requested when minting a completion-writing access token.
+    COMPLETION_SCOPE = getattr(
+        settings,
+        'ENTERPRISE_CORNERSTONE_OAUTH_SCOPE',
+        'transcript:update',
+    )
 
     def __init__(self, enterprise_configuration):
         """
@@ -85,25 +105,101 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
 
     def create_course_completion(self, user_id, payload):
         """
-        Send a completion status payload to the Cornerstone Completion Status endpoint
+        Send a learner's completion to Cornerstone.
+
+        Routed one of two ways, depending on whether the customer has been migrated:
+
+        - Transcript API (migrated): PATCH the learner's transcript with an OAuth access token we
+          mint and refresh ourselves. No dependency on the learner's launch-time session token.
+        - Completion callback (legacy): POST to the callback URL Cornerstone gave us at launch,
+          authenticated with the session token from that same launch. That token expires in roughly
+          two hours and we cannot refresh it, so completions sent later than that get a 401 back.
 
         Raises:
             HTTPError: if we received a failure response code from Cornerstone
         """
-        IntegratedChannelAPIRequestLogs = apps.get_model(
-            "channel_integration", "IntegratedChannelAPIRequestLogs"
-        )
         json_payload = json.loads(payload)
-        callback_url = json_payload['data'].pop('callbackUrl')
+        if self.enterprise_configuration.uses_oauth_completion_auth:
+            return self._complete_transcript(json_payload['data'])
+        return self._post_completion_callback(json_payload['data'])
+
+    def _complete_transcript(self, data):
+        """
+        Mark a learner's transcript complete through Cornerstone's Transcript API.
+
+        Args:
+            data (dict): the serialized audit record.
+
+        Returns: (status_code, response_text)
+        """
+        # The Transcript API's completion endpoint only marks a transcript complete; it has no
+        # notion of partial progress. In-progress records have nowhere to go here, so they are
+        # skipped rather than sent as something they are not.
+        if data.get('status') != 'Completed':
+            LOGGER.info(
+                generate_formatted_log(
+                    self.enterprise_configuration.channel_code(),
+                    self.enterprise_configuration.enterprise_customer.uuid,
+                    None,
+                    data.get('courseId'),
+                    'Skipping transcript update: the Transcript API only accepts completions and this '
+                    'record has status {status}.'.format(status=data.get('status'))
+                )
+            )
+            return 200, ''
+
+        url = urljoin(
+            self.enterprise_configuration.cornerstone_base_url,
+            self.TRANSCRIPT_COMPLETE_API_PATH,
+        )
+        transcript_payload = {
+            'userGuid': data.get('userGuid'),
+            'learningObjectId': self._get_learning_object_id(data.get('courseId')),
+            'ignoreWorkflow': True,
+        }
+
+        self._create_session()
+        start_time = time.time()
+        response = self.session.patch(url, json=transcript_payload)
+        duration_seconds = time.time() - start_time
+        self._store_api_call(url, transcript_payload, duration_seconds, response)
+        return response.status_code, response.text
+
+    def _get_learning_object_id(self, course_id):
+        """
+        Return the identifier Cornerstone knows this course by.
+
+        Cornerstone builds its learning objects by pulling our course-list feed, where each course
+        is published under ``CornerstoneCourseKey.external_course_id``. That is the only identifier
+        shared between the two systems, so it is what we key the transcript update on.
+
+        If Cornerstone turns out to require its own internally-generated learning object GUID
+        instead, this is the single place that needs to grow a lookup against their learning object
+        API, plus somewhere to cache the result.
+        """
+        return get_or_create_key_pair(course_id).external_course_id
+
+    def _post_completion_callback(self, data):
+        """
+        Legacy path: POST the completion to the callback URL captured at course launch.
+
+        Used for customers who have not been given OAuth credentials yet. Authenticated with the
+        launch-time session token, which is why it fails once that token ages out.
+
+        Args:
+            data (dict): the serialized audit record.
+
+        Returns: (status_code, response_text)
+        """
+        callback_url = data.pop('callbackUrl')
         session_token = self.enterprise_configuration.session_token
         if not session_token:
-            session_token = json_payload['data'].pop('sessionToken')
+            session_token = data.pop('sessionToken')
 
         # When exporting content metadata, we encode course keys that contain invalid chars or
         # set them to uuids to comply with Cornerstone standards
-        course_id = json_payload['data'].get('courseId')
-        key_mapping = get_or_create_key_pair(course_id)
-        json_payload['data']['courseId'] = key_mapping.external_course_id
+        data['courseId'] = self._get_learning_object_id(data.get('courseId'))
+
         url = '{base_url}{callback_url}{completion_path}?sessionToken={session_token}'.format(
             base_url=self.enterprise_configuration.cornerstone_base_url,
             callback_url=callback_url,
@@ -113,29 +209,108 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
         start_time = time.time()
         response = requests.post(
             url,
-            json=[json_payload['data']],
+            json=[data],
             headers={
                 'Authorization': self.authorization_header,
                 'Content-Type': 'application/json'
             }
         )
         duration_seconds = time.time() - start_time
+        self._store_api_call(url, data, duration_seconds, response)
+        return response.status_code, response.text
+
+    def _store_api_call(self, url, payload, duration_seconds, response):
+        """
+        Record an outbound call against the customer's API request log.
+        """
+        IntegratedChannelAPIRequestLogs = apps.get_model(
+            "channel_integration", "IntegratedChannelAPIRequestLogs"
+        )
         IntegratedChannelAPIRequestLogs.store_api_call(
             enterprise_customer=self.enterprise_configuration.enterprise_customer,
             enterprise_customer_configuration_id=self.enterprise_configuration.id,
             endpoint=url,
-            payload=json.dumps(json_payload["data"]),
+            payload=json.dumps(payload),
             time_taken=duration_seconds,
             status_code=response.status_code,
             response_body=response.text,
             channel_name=self.enterprise_configuration.channel_code()
         )
-        return response.status_code, response.text
 
     def create_assessment_reporting(self, user_id, payload):
         """
         Not implemented yet
         """
+
+    def get_oauth_url(self):
+        """
+        Full URL of the customer's Cornerstone token endpoint.
+        """
+        oauth_api_path = self.global_cornerstone_config.oauth_api_path or self.DEFAULT_OAUTH_API_PATH
+        return urljoin(self.enterprise_configuration.cornerstone_base_url, oauth_api_path)
+
+    def _create_session(self):
+        """
+        Instantiate a new session object for use in connecting with Cornerstone.
+
+        Reuses the existing session until its access token is due to expire, then mints a new one.
+        """
+        self.session, self.expires_at = refresh_session_if_expired(
+            self._get_oauth_access_token,
+            self.session,
+            self.expires_at,
+        )
+
+    def _get_oauth_access_token(self):
+        """
+        Retrieve an OAuth 2.0 access token using the client credentials grant.
+
+        Returns:
+            tuple: access token string and its lifetime in seconds.
+
+        Raises:
+            ClientError: If Cornerstone returned a response we could not read a token out of.
+        """
+        config = self.enterprise_configuration
+        url = self.get_oauth_url()
+        data = {
+            'grant_type': 'client_credentials',
+            'scope': self.COMPLETION_SCOPE,
+            'client_id': config.decrypted_client_id,
+            'client_secret': config.decrypted_client_secret,
+        }
+        start_time = time.time()
+        response = requests.post(
+            url,
+            data=data,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'}
+        )
+        duration_seconds = time.time() - start_time
+        IntegratedChannelAPIRequestLogs = apps.get_model(
+            "channel_integration", "IntegratedChannelAPIRequestLogs"
+        )
+        IntegratedChannelAPIRequestLogs.store_api_call(
+            enterprise_customer=config.enterprise_customer,
+            enterprise_customer_configuration_id=config.id,
+            endpoint=url,
+            # Neither the request nor the response body is stored verbatim: one carries the client
+            # secret, the other the access token. Failures keep their body, which is what we debug on.
+            payload=json.dumps({'grant_type': data['grant_type'], 'scope': data['scope']}),
+            time_taken=duration_seconds,
+            status_code=response.status_code,
+            response_body='<access token redacted>' if response.ok else response.text,
+            channel_name=config.channel_code()
+        )
+
+        try:
+            token_response = response.json()
+            return token_response['access_token'], token_response.get('expires_in')
+        except (KeyError, ValueError) as error:
+            raise ClientError(
+                'CornerstoneAPIClient failed to obtain an OAuth access token from {url}: '
+                'status_code={status_code}'.format(url=url, status_code=response.status_code),
+                status_code=response.status_code,
+            ) from error
 
     @property
     def authorization_header(self):

--- a/channel_integrations/cornerstone/migrations/0004_cornerstoneenterprisecustomerconfiguration_oauth_credentials.py
+++ b/channel_integrations/cornerstone/migrations/0004_cornerstoneenterprisecustomerconfiguration_oauth_credentials.py
@@ -1,0 +1,22 @@
+import fernet_fields.fields
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cornerstone_channel', '0003_alter_cornerstoneenterprisecustomerconfiguration_id_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cornerstoneenterprisecustomerconfiguration',
+            name='decrypted_client_id',
+            field=fernet_fields.fields.EncryptedCharField(blank=True, default='', help_text="The encrypted OAuth Client ID provided to edX by the enterprise customer, used to obtain access tokens for pushing course completions. When both this and the client secret are set, completions are authenticated with OAuth instead of the learner's launch-time session token.", max_length=255, null=True, verbose_name='Encrypted OAuth Client ID'),
+        ),
+        migrations.AddField(
+            model_name='cornerstoneenterprisecustomerconfiguration',
+            name='decrypted_client_secret',
+            field=fernet_fields.fields.EncryptedCharField(blank=True, default='', help_text='The encrypted OAuth Client Secret provided to edX by the enterprise customer, used to obtain access tokens for pushing course completions.', max_length=255, null=True, verbose_name='Encrypted OAuth Client Secret'),
+        ),
+    ]

--- a/channel_integrations/cornerstone/models.py
+++ b/channel_integrations/cornerstone/models.py
@@ -9,8 +9,10 @@ from config_models.models import ConfigurationModel
 from django.conf import settings
 from django.contrib import auth
 from django.db import models
+from django.utils.encoding import force_bytes, force_str
 from django.utils.translation import gettext_lazy as _
 from enterprise.models import EnterpriseCustomer
+from fernet_fields import EncryptedCharField
 from jsonfield import JSONField
 
 from channel_integrations.cornerstone.exporters.content_metadata import CornerstoneContentMetadataExporter
@@ -123,6 +125,75 @@ class CornerstoneEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfigu
         help_text=_("The base URL used for API requests to Cornerstone, i.e. https://portalName.csod.com")
     )
 
+    decrypted_client_id = EncryptedCharField(
+        max_length=255,
+        blank=True,
+        default='',
+        verbose_name="Encrypted OAuth Client ID",
+        help_text=_(
+            "The encrypted OAuth Client ID provided to edX by the enterprise customer, used to obtain access tokens "
+            "for pushing course completions. When both this and the client secret are set, completions are "
+            "authenticated with OAuth instead of the learner's launch-time session token."
+        ),
+        null=True
+    )
+
+    @property
+    def encrypted_client_id(self):
+        """
+        Return encrypted client_id as a string.
+        The data is encrypted in the DB at rest, but is unencrypted in the app when retrieved through the
+        decrypted_client_id field. This method will encrypt the client_id again before sending.
+        """
+        if self.decrypted_client_id:
+            return force_str(
+                self._meta.get_field('decrypted_client_id').fernet.encrypt(
+                    force_bytes(self.decrypted_client_id)
+                )
+            )
+        return self.decrypted_client_id
+
+    @encrypted_client_id.setter
+    def encrypted_client_id(self, value):
+        """
+        Set the encrypted client_id.
+        """
+        self.decrypted_client_id = value
+
+    decrypted_client_secret = EncryptedCharField(
+        max_length=255,
+        blank=True,
+        default='',
+        verbose_name="Encrypted OAuth Client Secret",
+        help_text=_(
+            "The encrypted OAuth Client Secret provided to edX by the enterprise customer, used to obtain access "
+            "tokens for pushing course completions."
+        ),
+        null=True
+    )
+
+    @property
+    def encrypted_client_secret(self):
+        """
+        Return encrypted client_secret as a string.
+        The data is encrypted in the DB at rest, but is unencrypted in the app when retrieved through the
+        decrypted_client_secret field. This method will encrypt the client_secret again before sending.
+        """
+        if self.decrypted_client_secret:
+            return force_str(
+                self._meta.get_field('decrypted_client_secret').fernet.encrypt(
+                    force_bytes(self.decrypted_client_secret)
+                )
+            )
+        return self.decrypted_client_secret
+
+    @encrypted_client_secret.setter
+    def encrypted_client_secret(self, value):
+        """
+        Set the encrypted client_secret.
+        """
+        self.decrypted_client_secret = value
+
     session_token = models.CharField(
         max_length=255,
         blank=True,
@@ -150,6 +221,16 @@ class CornerstoneEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfigu
 
     class Meta:
         app_label = 'cornerstone_channel'
+
+    @property
+    def uses_oauth_completion_auth(self):
+        """
+        Whether course completions for this customer should be authenticated with OAuth.
+
+        OAuth is opt-in per customer: a config with no credentials keeps using the learner's
+        launch-time session token, so existing customers are unaffected until credentials are set.
+        """
+        return bool(self.decrypted_client_id and self.decrypted_client_secret)
 
     @property
     def is_valid(self):

--- a/tests/test_channel_integrations/test_api/test_cornerstone/test_views.py
+++ b/tests/test_channel_integrations/test_api/test_cornerstone/test_views.py
@@ -84,11 +84,31 @@ class CornerstoneConfigurationViewSetTests(APITest):
         payload = {
             'cornerstone_base_url': 'http://testing2',
             'enterprise_customer': ENTERPRISE_ID,
+            'client_id': 'testing',
+            'client_secret': 'secret',
         }
         response = self.client.put(url, payload)
         self.cornerstone_config.refresh_from_db()
         self.assertEqual(self.cornerstone_config.cornerstone_base_url, 'http://testing2')
+        self.assertEqual(self.cornerstone_config.decrypted_client_id, 'testing')
+        self.assertEqual(self.cornerstone_config.decrypted_client_secret, 'secret')
+        self.assertTrue(self.cornerstone_config.uses_oauth_completion_auth)
         self.assertEqual(response.status_code, 200)
+
+    @mock.patch('enterprise.rules.crum.get_current_request')
+    def test_oauth_is_opt_in(self, mock_current_request):
+        """
+        A config with no credentials keeps using the legacy session-token auth, and stays valid.
+        """
+        mock_current_request.return_value = self.get_request_with_jwt_cookie(
+            system_wide_role=ENTERPRISE_ADMIN_ROLE,
+            context=self.enterprise_customer.uuid,
+        )
+        self.assertFalse(self.cornerstone_config.uses_oauth_completion_auth)
+
+        url = reverse('api:v1:cornerstone:configuration-detail', args=[self.cornerstone_config.id])
+        data = json.loads(self.client.get(url).content.decode('utf-8'))
+        self.assertEqual(data.get('is_valid'), [{'missing': []}, {'incorrect': []}])
 
     @mock.patch('enterprise.rules.crum.get_current_request')
     def test_patch(self, mock_current_request):

--- a/tests/test_channel_integrations/test_cornerstone/test_client.py
+++ b/tests/test_channel_integrations/test_cornerstone/test_client.py
@@ -4,6 +4,7 @@ Tests for Degreed2 client for channel_integrations.
 
 import json
 import unittest
+from urllib.parse import urljoin
 
 import pytest
 import responses
@@ -11,6 +12,8 @@ import responses
 from django.apps import apps
 
 from channel_integrations.cornerstone.client import CornerstoneAPIClient
+from channel_integrations.cornerstone.utils import get_or_create_key_pair
+from channel_integrations.exceptions import ClientError
 from test_utils import factories
 
 IntegratedChannelAPIRequestLogs = apps.get_model(
@@ -60,3 +63,171 @@ class TestCornerstoneApiClient(unittest.TestCase):
         assert IntegratedChannelAPIRequestLogs.objects.count() == 1
         assert len(responses.calls) == 1
         assert output == (200, '"{}"')
+
+    def _migrate_config_to_oauth(self):
+        """
+        Give the config OAuth credentials, which routes completions to the Transcript API.
+        """
+        self.csod_config.decrypted_client_id = "dummy_client_id"
+        self.csod_config.decrypted_client_secret = "dummy_client_secret"
+        self.csod_config.save()
+
+    def _transcript_url(self, client):
+        return urljoin(self.cornerstone_base_url, client.TRANSCRIPT_COMPLETE_API_PATH)
+
+    @staticmethod
+    def _completion_payload(**overrides):
+        data = {
+            "userGuid": "dummy_guid",
+            "courseId": "edX+DemoX",
+            "status": "Completed",
+            "successStatus": "Pass",
+            "sessionToken": "expired_session_token",
+            "callbackUrl": "dummy_callback_url",
+            "subdomain": "dummy_subdomain",
+        }
+        data.update(overrides)
+        return json.dumps({"data": data})
+
+    @responses.activate
+    def test_completion_goes_to_the_transcript_api_once_migrated(self):
+        """
+        With OAuth credentials configured, a completion should PATCH the Transcript API with a
+        bearer token, and carry no session token anywhere.
+        """
+        self._migrate_config_to_oauth()
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+        transcript_url = self._transcript_url(cornerstone_api_client)
+
+        responses.add(
+            responses.POST,
+            cornerstone_api_client.get_oauth_url(),
+            json={"access_token": "dummy_access_token", "expires_in": 3600},
+            status=200,
+        )
+        responses.add(responses.PATCH, transcript_url, json="{}", status=200)
+
+        output = cornerstone_api_client.create_course_completion(
+            "test-learner@example.com", self._completion_payload()
+        )
+
+        assert output == (200, '"{}"')
+        assert len(responses.calls) == 2
+
+        token_request = responses.calls[0]
+        transcript_request = responses.calls[1]
+        assert "client_credentials" in token_request.request.body
+        assert transcript_request.request.method == "PATCH"
+        assert transcript_request.request.url == transcript_url
+        assert transcript_request.request.headers["Authorization"] == "Bearer dummy_access_token"
+
+        body = json.loads(transcript_request.request.body)
+        assert body["userGuid"] == "dummy_guid"
+        assert body["ignoreWorkflow"] is True
+        # The learning object is keyed on the id we publish in the course-list feed.
+        assert body["learningObjectId"] == get_or_create_key_pair("edX+DemoX").external_course_id
+        assert "sessionToken" not in body
+        assert "sessionToken" not in transcript_request.request.url
+
+        # The token request body and the token itself are kept out of the stored API record.
+        token_record = IntegratedChannelAPIRequestLogs.objects.get(endpoint=token_request.request.url)
+        assert "dummy_client_secret" not in token_record.payload
+        assert "dummy_access_token" not in token_record.response_body
+
+    @responses.activate
+    def test_in_progress_records_are_skipped_on_the_transcript_api(self):
+        """
+        The Transcript API's completion endpoint only marks transcripts complete, so a record that
+        is still in progress should be skipped rather than sent.
+        """
+        self._migrate_config_to_oauth()
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+
+        output = cornerstone_api_client.create_course_completion(
+            "test-learner@example.com",
+            self._completion_payload(status="In Progress", successStatus=None),
+        )
+
+        assert output == (200, '')
+        assert len(responses.calls) == 0
+        assert IntegratedChannelAPIRequestLogs.objects.count() == 0
+
+    @responses.activate
+    def test_unmigrated_config_still_uses_the_legacy_callback(self):
+        """
+        A config with no OAuth credentials should keep posting to the launch-time callback URL.
+        """
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+        responses.add(
+            responses.POST,
+            f"{self.cornerstone_base_url}dummy_callback_url",
+            json="{}",
+            status=200,
+        )
+
+        output = cornerstone_api_client.create_course_completion(
+            "test-learner@example.com", self._completion_payload()
+        )
+
+        assert output == (200, '"{}"')
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.method == "POST"
+        assert "sessionToken=expired_session_token" in responses.calls[0].request.url
+
+    @responses.activate
+    def test_create_course_completion_reuses_unexpired_access_token(self):
+        """
+        A second completion in the same client's lifetime should reuse the existing access token.
+        """
+        self._migrate_config_to_oauth()
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+
+        responses.add(
+            responses.POST,
+            cornerstone_api_client.get_oauth_url(),
+            json={"access_token": "dummy_access_token", "expires_in": 3600},
+            status=200,
+        )
+        responses.add(
+            responses.PATCH,
+            self._transcript_url(cornerstone_api_client),
+            json="{}",
+            status=200,
+        )
+
+        cornerstone_api_client.create_course_completion(
+            "test-learner@example.com", self._completion_payload()
+        )
+        cornerstone_api_client.create_course_completion(
+            "test-learner@example.com", self._completion_payload()
+        )
+
+        token_calls = [
+            call for call in responses.calls
+            if call.request.url == cornerstone_api_client.get_oauth_url()
+        ]
+        assert len(token_calls) == 1
+
+    @responses.activate
+    def test_get_oauth_access_token_raises_on_unparseable_response(self):
+        """
+        A token endpoint that does not hand back an ``access_token`` should raise a ``ClientError``.
+        """
+        self.csod_config.decrypted_client_id = "dummy_client_id"
+        self.csod_config.decrypted_client_secret = "dummy_client_secret"
+        self.csod_config.save()
+
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+        responses.add(
+            responses.POST,
+            cornerstone_api_client.get_oauth_url(),
+            json={"error": "invalid_client"},
+            status=401,
+        )
+
+        with pytest.raises(ClientError):
+            cornerstone_api_client._get_oauth_access_token()  # pylint: disable=protected-access
+
+        # Failures keep their response body, which is what we debug on.
+        token_record = IntegratedChannelAPIRequestLogs.objects.get()
+        assert "invalid_client" in token_record.response_body


### PR DESCRIPTION
[ENT-12045](https://2u-internal.atlassian.net/browse/ENT-12045)

## What

CSOD completions are POSTed to the launch-time callback URL, authenticated with the `sessionToken` from that launch. That token lasts ~2h and is never refreshed, so completions sent later get a 401.

This migrates the push to Cornerstone's Transcript API (`PATCH /services/api/v1/transcripts/complete`), authenticated with OAuth client credentials we mint and refresh ourselves. New encrypted `client_id` / `client_secret` on the CSOD config (migration `0004`), writable via the config API and admin.

**Opt-in per customer.** No credentials set means the config keeps using the legacy callback and stays `is_valid`, so customers migrate one at a time.

## Reviewer input wanted

- **`learningObjectId` is keyed on `CornerstoneCourseKey.external_course_id`** — the id we publish in the course-list feed CSOD builds its LOs from. If CSOD needs their own GUID, `_get_learning_object_id` is the seam for a lookup. Unconfirmed with them.
- **In-progress records are no longer transmitted for migrated customers.** `transcripts/complete` only marks completion; those are skipped with a log. Behaviour change — needs a follow-up if customers rely on progress data.

## Testing

`914 passed`, pylint and pycodestyle clean. Token endpoint, grant type and `transcript:update` scope verified against a live CSOD portal (HTTP 200, `expires_in: 3600`). The `PATCH` itself is unexercised — it is a write against customer production, so it needs a pilot portal first.