### PR TITLE
feat: migrate CSOD learner data transmission to the Transcript API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 **********
 
+0.1.66 – 2026-08-04
+*******************
+
+* feat: migrate Cornerstone learner data transmission from the launch-time completion callback to Cornerstone's
+  Transcript API, authenticated with OAuth client credentials instead of the learner's session token; opt-in per
+  customer via new encrypted ``client_id`` / ``client_secret`` config fields
+
 0.1.65 – 2026-07-22
 *******************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,6 @@ Unreleased
 0.1.66 – 2026-08-04
 *******************
 
-* fix: add override method to omit hours fields when disabled
 * feat: migrate Cornerstone learner data transmission from the launch-time completion callback to Cornerstone's
   Transcript API, authenticated with OAuth client credentials instead of the learner's session token; opt-in per
   customer via new encrypted ``client_id`` / ``client_secret`` config fields

--- a/channel_integrations/__init__.py
+++ b/channel_integrations/__init__.py
@@ -5,4 +5,4 @@ An integrated channel is an abstraction meant to represent a third-party system
 which provides an API that can be used to transmit EdX data to the third-party system.
 """
 
-__version__ = '0.1.65'  # pragma: no cover
+__version__ = '0.1.66'  # pragma: no cover

--- a/channel_integrations/api/v1/cornerstone/serializers.py
+++ b/channel_integrations/api/v1/cornerstone/serializers.py
@@ -1,6 +1,8 @@
 """
     Serializer for Cornerstone configuration.
 """
+from rest_framework import serializers
+
 from channel_integrations.api.serializers import EnterpriseCustomerPluginConfigSerializer
 from channel_integrations.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
 
@@ -10,7 +12,43 @@ class CornerstoneConfigSerializer(EnterpriseCustomerPluginConfigSerializer):
         model = CornerstoneEnterpriseCustomerConfiguration
         extra_fields = (
             'cornerstone_base_url',
+            'client_id',
+            'client_secret',
             'session_token',
             'session_token_modified'
         )
         fields = EnterpriseCustomerPluginConfigSerializer.Meta.fields + extra_fields
+
+    client_id = serializers.CharField(
+        required=False, allow_blank=False, read_only=False
+    )
+    client_secret = serializers.CharField(
+        required=False, allow_blank=False, read_only=False
+    )
+
+    def _handle_credentials(self, instance, client_id=None, client_secret=None):
+        """
+        Helper to update credentials consistently.
+        """
+        if client_id is not None:
+            instance.encrypted_client_id = client_id
+        if client_secret is not None:
+            instance.encrypted_client_secret = client_secret
+
+    def create(self, validated_data):
+        client_id = validated_data.pop("client_id", None)
+        client_secret = validated_data.pop("client_secret", None)
+
+        instance = super().create(validated_data)
+        self._handle_credentials(instance, client_id, client_secret)
+        instance.save()
+        return instance
+
+    def update(self, instance, validated_data):
+        client_id = validated_data.pop("client_id", None)
+        client_secret = validated_data.pop("client_secret", None)
+
+        instance = super().update(instance, validated_data)
+        self._handle_credentials(instance, client_id, client_secret)
+        instance.save()
+        return instance

--- a/channel_integrations/cornerstone/admin/__init__.py
+++ b/channel_integrations/cornerstone/admin/__init__.py
@@ -42,6 +42,7 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin
         "enterprise_customer_name",
         "active",
         "cornerstone_base_url",
+        "oauth_configured",
     )
 
     readonly_fields = (
@@ -70,6 +71,18 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin
                 being rendered with this admin form.
         """
         return obj.enterprise_customer.name
+
+    @admin.display(boolean=True, description="OAuth configured")
+    def oauth_configured(self, obj):
+        """
+        Returns: whether completions for this customer are authenticated with OAuth rather than
+        the learner's launch-time session token.
+
+        Args:
+            obj: The instance of CornerstoneEnterpriseCustomerConfiguration
+                being rendered with this admin form.
+        """
+        return obj.uses_oauth_completion_auth
 
     @admin.action(
         description="Force content metadata transmission for this Enterprise Customer"

--- a/channel_integrations/cornerstone/client.py
+++ b/channel_integrations/cornerstone/client.py
@@ -38,11 +38,20 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
         '/services/api/v1/transcripts/complete',
     )
 
-    # Scope requested when minting a completion-writing access token.
+    # Cornerstone's Learning Assignments API endpoint for looking up/updating a learner's
+    # in-progress assignment record.
+    LEARNING_ASSIGNMENTS_API_PATH = getattr(
+        settings,
+        'ENTERPRISE_CORNERSTONE_LEARNING_ASSIGNMENTS_PATH',
+        '/services/api/v1/LearningAssignments',
+    )
+
+    # Scope requested when minting a completion-writing access token. Covers both the Transcript
+    # API (completions) and the Learning Assignments API (in-progress updates).
     COMPLETION_SCOPE = getattr(
         settings,
         'ENTERPRISE_CORNERSTONE_OAUTH_SCOPE',
-        'transcript:update',
+        'transcript:update learningassignment:read learningassignment:update',
     )
 
     def __init__(self, enterprise_configuration):
@@ -119,9 +128,12 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
             HTTPError: if we received a failure response code from Cornerstone
         """
         json_payload = json.loads(payload)
+        data = json_payload['data']
         if self.enterprise_configuration.uses_oauth_completion_auth:
-            return self._complete_transcript(json_payload['data'])
-        return self._post_completion_callback(json_payload['data'])
+            if data.get('status') == 'Completed':
+                return self._complete_transcript(data)
+            return self._update_learning_assignment(data)
+        return self._post_completion_callback(data)
 
     def _complete_transcript(self, data):
         """
@@ -132,22 +144,6 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
 
         Returns: (status_code, response_text)
         """
-        # The Transcript API's completion endpoint only marks a transcript complete; it has no
-        # notion of partial progress. In-progress records have nowhere to go here, so they are
-        # skipped rather than sent as something they are not.
-        if data.get('status') != 'Completed':
-            LOGGER.info(
-                generate_formatted_log(
-                    self.enterprise_configuration.channel_code(),
-                    self.enterprise_configuration.enterprise_customer.uuid,
-                    None,
-                    data.get('courseId'),
-                    'Skipping transcript update: the Transcript API only accepts completions and this '
-                    'record has status {status}.'.format(status=data.get('status'))
-                )
-            )
-            return 200, ''
-
         url = urljoin(
             self.enterprise_configuration.cornerstone_base_url,
             self.TRANSCRIPT_COMPLETE_API_PATH,
@@ -178,6 +174,74 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
         API, plus somewhere to cache the result.
         """
         return get_or_create_key_pair(course_id).external_course_id
+
+    def _update_learning_assignment(self, data):
+        """
+        Update a learner's in-progress assignment through Cornerstone's Learning Assignments API.
+
+        The Transcript API only understands completions, so in-progress records are sent here
+        instead: first resolving the assignment ID for this learner/course pair, then patching
+        its status and last-accessed date.
+
+        Args:
+            data (dict): the serialized audit record.
+
+        Returns: (status_code, response_text)
+        """
+        self._create_session()
+
+        learning_object_id = self._get_learning_object_id(data.get('courseId'))
+        lookup_url = urljoin(
+            self.enterprise_configuration.cornerstone_base_url,
+            self.LEARNING_ASSIGNMENTS_API_PATH,
+        )
+        start_time = time.time()
+        lookup_response = self.session.get(
+            lookup_url,
+            params={
+                'userId': data.get('userGuid'),
+                'loId': learning_object_id,
+            },
+        )
+        duration_seconds = time.time() - start_time
+        self._store_api_call(lookup_url, {'userId': data.get('userGuid'), 'loId': learning_object_id},
+                              duration_seconds, lookup_response)
+
+        if not lookup_response.ok:
+            return lookup_response.status_code, lookup_response.text
+
+        try:
+            assignment_id = lookup_response.json()[0]['assignmentId']
+        except (KeyError, IndexError, ValueError):
+            LOGGER.info(
+                generate_formatted_log(
+                    self.enterprise_configuration.channel_code(),
+                    self.enterprise_configuration.enterprise_customer.uuid,
+                    None,
+                    data.get('courseId'),
+                    'Skipping learning assignment update: no assignment found for userGuid '
+                    '{user_guid} and learning object {lo_id}.'.format(
+                        user_guid=data.get('userGuid'), lo_id=learning_object_id
+                    )
+                )
+            )
+            return 200, ''
+
+        update_url = urljoin(
+            self.enterprise_configuration.cornerstone_base_url,
+            '{path}/{assignment_id}'.format(
+                path=self.LEARNING_ASSIGNMENTS_API_PATH, assignment_id=assignment_id
+            ),
+        )
+        assignment_payload = {
+            'Status': data.get('status'),
+            'LastAccessDate': data.get('completionDate'),
+        }
+        start_time = time.time()
+        response = self.session.patch(update_url, json=assignment_payload)
+        duration_seconds = time.time() - start_time
+        self._store_api_call(update_url, assignment_payload, duration_seconds, response)
+        return response.status_code, response.text
 
     def _post_completion_callback(self, data):
         """

--- a/channel_integrations/cornerstone/client.py
+++ b/channel_integrations/cornerstone/client.py
@@ -6,13 +6,16 @@ import base64
 import json
 import logging
 import time
+from urllib.parse import urljoin
 
 import requests
 from django.apps import apps
+from django.conf import settings
 
 from channel_integrations.cornerstone.utils import get_or_create_key_pair
+from channel_integrations.exceptions import ClientError
 from channel_integrations.integrated_channel.client import IntegratedChannelApiClient
-from channel_integrations.utils import generate_formatted_log
+from channel_integrations.utils import generate_formatted_log, refresh_session_if_expired
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,6 +27,23 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
     Specifically, this class supports obtaining access tokens
     and posting user's course completion status to progress endpoints.
     """
+
+    # Fallback used when CornerstoneGlobalConfiguration.oauth_api_path is not set.
+    DEFAULT_OAUTH_API_PATH = '/services/api/oauth2/token'
+
+    # Cornerstone's Transcript API endpoint for marking a learner's transcript complete.
+    TRANSCRIPT_COMPLETE_API_PATH = getattr(
+        settings,
+        'ENTERPRISE_CORNERSTONE_TRANSCRIPT_COMPLETE_PATH',
+        '/services/api/v1/transcripts/complete',
+    )
+
+    # Scope requested when minting a completion-writing access token.
+    COMPLETION_SCOPE = getattr(
+        settings,
+        'ENTERPRISE_CORNERSTONE_OAUTH_SCOPE',
+        'transcript:update',
+    )
 
     def __init__(self, enterprise_configuration):
         """
@@ -85,25 +105,101 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
 
     def create_course_completion(self, user_id, payload):
         """
-        Send a completion status payload to the Cornerstone Completion Status endpoint
+        Send a learner's completion to Cornerstone.
+
+        Routed one of two ways, depending on whether the customer has been migrated:
+
+        - Transcript API (migrated): PATCH the learner's transcript with an OAuth access token we
+          mint and refresh ourselves. No dependency on the learner's launch-time session token.
+        - Completion callback (legacy): POST to the callback URL Cornerstone gave us at launch,
+          authenticated with the session token from that same launch. That token expires in roughly
+          two hours and we cannot refresh it, so completions sent later than that get a 401 back.
 
         Raises:
             HTTPError: if we received a failure response code from Cornerstone
         """
-        IntegratedChannelAPIRequestLogs = apps.get_model(
-            "channel_integration", "IntegratedChannelAPIRequestLogs"
-        )
         json_payload = json.loads(payload)
-        callback_url = json_payload['data'].pop('callbackUrl')
+        if self.enterprise_configuration.uses_oauth_completion_auth:
+            return self._complete_transcript(json_payload['data'])
+        return self._post_completion_callback(json_payload['data'])
+
+    def _complete_transcript(self, data):
+        """
+        Mark a learner's transcript complete through Cornerstone's Transcript API.
+
+        Args:
+            data (dict): the serialized audit record.
+
+        Returns: (status_code, response_text)
+        """
+        # The Transcript API's completion endpoint only marks a transcript complete; it has no
+        # notion of partial progress. In-progress records have nowhere to go here, so they are
+        # skipped rather than sent as something they are not.
+        if data.get('status') != 'Completed':
+            LOGGER.info(
+                generate_formatted_log(
+                    self.enterprise_configuration.channel_code(),
+                    self.enterprise_configuration.enterprise_customer.uuid,
+                    None,
+                    data.get('courseId'),
+                    'Skipping transcript update: the Transcript API only accepts completions and this '
+                    'record has status {status}.'.format(status=data.get('status'))
+                )
+            )
+            return 200, ''
+
+        url = urljoin(
+            self.enterprise_configuration.cornerstone_base_url,
+            self.TRANSCRIPT_COMPLETE_API_PATH,
+        )
+        transcript_payload = {
+            'userGuid': data.get('userGuid'),
+            'learningObjectId': self._get_learning_object_id(data.get('courseId')),
+            'ignoreWorkflow': True,
+        }
+
+        self._create_session()
+        start_time = time.time()
+        response = self.session.patch(url, json=transcript_payload)
+        duration_seconds = time.time() - start_time
+        self._store_api_call(url, transcript_payload, duration_seconds, response)
+        return response.status_code, response.text
+
+    def _get_learning_object_id(self, course_id):
+        """
+        Return the identifier Cornerstone knows this course by.
+
+        Cornerstone builds its learning objects by pulling our course-list feed, where each course
+        is published under ``CornerstoneCourseKey.external_course_id``. That is the only identifier
+        shared between the two systems, so it is what we key the transcript update on.
+
+        If Cornerstone turns out to require its own internally-generated learning object GUID
+        instead, this is the single place that needs to grow a lookup against their learning object
+        API, plus somewhere to cache the result.
+        """
+        return get_or_create_key_pair(course_id).external_course_id
+
+    def _post_completion_callback(self, data):
+        """
+        Legacy path: POST the completion to the callback URL captured at course launch.
+
+        Used for customers who have not been given OAuth credentials yet. Authenticated with the
+        launch-time session token, which is why it fails once that token ages out.
+
+        Args:
+            data (dict): the serialized audit record.
+
+        Returns: (status_code, response_text)
+        """
+        callback_url = data.pop('callbackUrl')
         session_token = self.enterprise_configuration.session_token
         if not session_token:
-            session_token = json_payload['data'].pop('sessionToken')
+            session_token = data.pop('sessionToken')
 
         # When exporting content metadata, we encode course keys that contain invalid chars or
         # set them to uuids to comply with Cornerstone standards
-        course_id = json_payload['data'].get('courseId')
-        key_mapping = get_or_create_key_pair(course_id)
-        json_payload['data']['courseId'] = key_mapping.external_course_id
+        data['courseId'] = self._get_learning_object_id(data.get('courseId'))
+
         url = '{base_url}{callback_url}{completion_path}?sessionToken={session_token}'.format(
             base_url=self.enterprise_configuration.cornerstone_base_url,
             callback_url=callback_url,
@@ -113,29 +209,108 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
         start_time = time.time()
         response = requests.post(
             url,
-            json=[json_payload['data']],
+            json=[data],
             headers={
                 'Authorization': self.authorization_header,
                 'Content-Type': 'application/json'
             }
         )
         duration_seconds = time.time() - start_time
+        self._store_api_call(url, data, duration_seconds, response)
+        return response.status_code, response.text
+
+    def _store_api_call(self, url, payload, duration_seconds, response):
+        """
+        Record an outbound call against the customer's API request log.
+        """
+        IntegratedChannelAPIRequestLogs = apps.get_model(
+            "channel_integration", "IntegratedChannelAPIRequestLogs"
+        )
         IntegratedChannelAPIRequestLogs.store_api_call(
             enterprise_customer=self.enterprise_configuration.enterprise_customer,
             enterprise_customer_configuration_id=self.enterprise_configuration.id,
             endpoint=url,
-            payload=json.dumps(json_payload["data"]),
+            payload=json.dumps(payload),
             time_taken=duration_seconds,
             status_code=response.status_code,
             response_body=response.text,
             channel_name=self.enterprise_configuration.channel_code()
         )
-        return response.status_code, response.text
 
     def create_assessment_reporting(self, user_id, payload):
         """
         Not implemented yet
         """
+
+    def get_oauth_url(self):
+        """
+        Full URL of the customer's Cornerstone token endpoint.
+        """
+        oauth_api_path = self.global_cornerstone_config.oauth_api_path or self.DEFAULT_OAUTH_API_PATH
+        return urljoin(self.enterprise_configuration.cornerstone_base_url, oauth_api_path)
+
+    def _create_session(self):
+        """
+        Instantiate a new session object for use in connecting with Cornerstone.
+
+        Reuses the existing session until its access token is due to expire, then mints a new one.
+        """
+        self.session, self.expires_at = refresh_session_if_expired(
+            self._get_oauth_access_token,
+            self.session,
+            self.expires_at,
+        )
+
+    def _get_oauth_access_token(self):
+        """
+        Retrieve an OAuth 2.0 access token using the client credentials grant.
+
+        Returns:
+            tuple: access token string and its lifetime in seconds.
+
+        Raises:
+            ClientError: If Cornerstone returned a response we could not read a token out of.
+        """
+        config = self.enterprise_configuration
+        url = self.get_oauth_url()
+        data = {
+            'grant_type': 'client_credentials',
+            'scope': self.COMPLETION_SCOPE,
+            'client_id': config.decrypted_client_id,
+            'client_secret': config.decrypted_client_secret,
+        }
+        start_time = time.time()
+        response = requests.post(
+            url,
+            data=data,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'}
+        )
+        duration_seconds = time.time() - start_time
+        IntegratedChannelAPIRequestLogs = apps.get_model(
+            "channel_integration", "IntegratedChannelAPIRequestLogs"
+        )
+        IntegratedChannelAPIRequestLogs.store_api_call(
+            enterprise_customer=config.enterprise_customer,
+            enterprise_customer_configuration_id=config.id,
+            endpoint=url,
+            # Neither the request nor the response body is stored verbatim: one carries the client
+            # secret, the other the access token. Failures keep their body, which is what we debug on.
+            payload=json.dumps({'grant_type': data['grant_type'], 'scope': data['scope']}),
+            time_taken=duration_seconds,
+            status_code=response.status_code,
+            response_body='<access token redacted>' if response.ok else response.text,
+            channel_name=config.channel_code()
+        )
+
+        try:
+            token_response = response.json()
+            return token_response['access_token'], token_response.get('expires_in')
+        except (KeyError, ValueError) as error:
+            raise ClientError(
+                'CornerstoneAPIClient failed to obtain an OAuth access token from {url}: '
+                'status_code={status_code}'.format(url=url, status_code=response.status_code),
+                status_code=response.status_code,
+            ) from error
 
     @property
     def authorization_header(self):

--- a/channel_integrations/cornerstone/migrations/0004_cornerstoneenterprisecustomerconfiguration_oauth_credentials.py
+++ b/channel_integrations/cornerstone/migrations/0004_cornerstoneenterprisecustomerconfiguration_oauth_credentials.py
@@ -1,0 +1,22 @@
+import fernet_fields.fields
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cornerstone_channel', '0003_alter_cornerstoneenterprisecustomerconfiguration_id_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cornerstoneenterprisecustomerconfiguration',
+            name='decrypted_client_id',
+            field=fernet_fields.fields.EncryptedCharField(blank=True, default='', help_text="The encrypted OAuth Client ID provided to edX by the enterprise customer, used to obtain access tokens for pushing course completions. When both this and the client secret are set, completions are authenticated with OAuth instead of the learner's launch-time session token.", max_length=255, null=True, verbose_name='Encrypted OAuth Client ID'),
+        ),
+        migrations.AddField(
+            model_name='cornerstoneenterprisecustomerconfiguration',
+            name='decrypted_client_secret',
+            field=fernet_fields.fields.EncryptedCharField(blank=True, default='', help_text='The encrypted OAuth Client Secret provided to edX by the enterprise customer, used to obtain access tokens for pushing course completions.', max_length=255, null=True, verbose_name='Encrypted OAuth Client Secret'),
+        ),
+    ]

--- a/channel_integrations/cornerstone/models.py
+++ b/channel_integrations/cornerstone/models.py
@@ -9,8 +9,10 @@ from config_models.models import ConfigurationModel
 from django.conf import settings
 from django.contrib import auth
 from django.db import models
+from django.utils.encoding import force_bytes, force_str
 from django.utils.translation import gettext_lazy as _
 from enterprise.models import EnterpriseCustomer
+from fernet_fields import EncryptedCharField
 from jsonfield import JSONField
 
 from channel_integrations.cornerstone.exporters.content_metadata import CornerstoneContentMetadataExporter
@@ -123,6 +125,75 @@ class CornerstoneEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfigu
         help_text=_("The base URL used for API requests to Cornerstone, i.e. https://portalName.csod.com")
     )
 
+    decrypted_client_id = EncryptedCharField(
+        max_length=255,
+        blank=True,
+        default='',
+        verbose_name="Encrypted OAuth Client ID",
+        help_text=_(
+            "The encrypted OAuth Client ID provided to edX by the enterprise customer, used to obtain access tokens "
+            "for pushing course completions. When both this and the client secret are set, completions are "
+            "authenticated with OAuth instead of the learner's launch-time session token."
+        ),
+        null=True
+    )
+
+    @property
+    def encrypted_client_id(self):
+        """
+        Return encrypted client_id as a string.
+        The data is encrypted in the DB at rest, but is unencrypted in the app when retrieved through the
+        decrypted_client_id field. This method will encrypt the client_id again before sending.
+        """
+        if self.decrypted_client_id:
+            return force_str(
+                self._meta.get_field('decrypted_client_id').fernet.encrypt(
+                    force_bytes(self.decrypted_client_id)
+                )
+            )
+        return self.decrypted_client_id
+
+    @encrypted_client_id.setter
+    def encrypted_client_id(self, value):
+        """
+        Set the encrypted client_id.
+        """
+        self.decrypted_client_id = value
+
+    decrypted_client_secret = EncryptedCharField(
+        max_length=255,
+        blank=True,
+        default='',
+        verbose_name="Encrypted OAuth Client Secret",
+        help_text=_(
+            "The encrypted OAuth Client Secret provided to edX by the enterprise customer, used to obtain access "
+            "tokens for pushing course completions."
+        ),
+        null=True
+    )
+
+    @property
+    def encrypted_client_secret(self):
+        """
+        Return encrypted client_secret as a string.
+        The data is encrypted in the DB at rest, but is unencrypted in the app when retrieved through the
+        decrypted_client_secret field. This method will encrypt the client_secret again before sending.
+        """
+        if self.decrypted_client_secret:
+            return force_str(
+                self._meta.get_field('decrypted_client_secret').fernet.encrypt(
+                    force_bytes(self.decrypted_client_secret)
+                )
+            )
+        return self.decrypted_client_secret
+
+    @encrypted_client_secret.setter
+    def encrypted_client_secret(self, value):
+        """
+        Set the encrypted client_secret.
+        """
+        self.decrypted_client_secret = value
+
     session_token = models.CharField(
         max_length=255,
         blank=True,
@@ -150,6 +221,16 @@ class CornerstoneEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfigu
 
     class Meta:
         app_label = 'cornerstone_channel'
+
+    @property
+    def uses_oauth_completion_auth(self):
+        """
+        Whether course completions for this customer should be authenticated with OAuth.
+
+        OAuth is opt-in per customer: a config with no credentials keeps using the learner's
+        launch-time session token, so existing customers are unaffected until credentials are set.
+        """
+        return bool(self.decrypted_client_id and self.decrypted_client_secret)
 
     @property
     def is_valid(self):

--- a/tests/test_channel_integrations/test_api/test_cornerstone/test_views.py
+++ b/tests/test_channel_integrations/test_api/test_cornerstone/test_views.py
@@ -84,11 +84,31 @@ class CornerstoneConfigurationViewSetTests(APITest):
         payload = {
             'cornerstone_base_url': 'http://testing2',
             'enterprise_customer': ENTERPRISE_ID,
+            'client_id': 'testing',
+            'client_secret': 'secret',
         }
         response = self.client.put(url, payload)
         self.cornerstone_config.refresh_from_db()
         self.assertEqual(self.cornerstone_config.cornerstone_base_url, 'http://testing2')
+        self.assertEqual(self.cornerstone_config.decrypted_client_id, 'testing')
+        self.assertEqual(self.cornerstone_config.decrypted_client_secret, 'secret')
+        self.assertTrue(self.cornerstone_config.uses_oauth_completion_auth)
         self.assertEqual(response.status_code, 200)
+
+    @mock.patch('enterprise.rules.crum.get_current_request')
+    def test_oauth_is_opt_in(self, mock_current_request):
+        """
+        A config with no credentials keeps using the legacy session-token auth, and stays valid.
+        """
+        mock_current_request.return_value = self.get_request_with_jwt_cookie(
+            system_wide_role=ENTERPRISE_ADMIN_ROLE,
+            context=self.enterprise_customer.uuid,
+        )
+        self.assertFalse(self.cornerstone_config.uses_oauth_completion_auth)
+
+        url = reverse('api:v1:cornerstone:configuration-detail', args=[self.cornerstone_config.id])
+        data = json.loads(self.client.get(url).content.decode('utf-8'))
+        self.assertEqual(data.get('is_valid'), [{'missing': []}, {'incorrect': []}])
 
     @mock.patch('enterprise.rules.crum.get_current_request')
     def test_patch(self, mock_current_request):

--- a/tests/test_channel_integrations/test_cornerstone/test_admin.py
+++ b/tests/test_channel_integrations/test_cornerstone/test_admin.py
@@ -10,8 +10,14 @@ from django.http import HttpRequest, HttpResponseRedirect
 from django.test import TestCase
 from pytest import mark
 
-from channel_integrations.cornerstone.admin import CornerstoneEnterpriseCustomerConfigurationAdmin
-from channel_integrations.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
+from channel_integrations.cornerstone.admin import (
+    CornerstoneEnterpriseCustomerConfigurationAdmin,
+    CornerstoneLearnerDataTransmissionAuditAdmin,
+)
+from channel_integrations.cornerstone.models import (
+    CornerstoneEnterpriseCustomerConfiguration,
+    CornerstoneLearnerDataTransmissionAudit,
+)
 from test_utils import factories
 
 
@@ -75,3 +81,51 @@ class TestCornerstoneEnterpriseCustomerConfigurationAdmin(TestCase):
         Test that the force_content_metadata_transmission method has the correct label.
         """
         assert self.admin_instance.force_content_metadata_transmission.label == "Force content metadata transmission"
+
+    def test_enterprise_customer_name(self):
+        """
+        Test the enterprise_customer_name method returns the associated enterprise customer's name.
+        """
+        assert self.admin_instance.enterprise_customer_name(
+            self.cornerstone_config
+        ) == self.cornerstone_config.enterprise_customer.name
+
+    def test_oauth_configured_false_by_default(self):
+        """
+        Test that oauth_configured is False when no OAuth credentials are set.
+        """
+        assert self.admin_instance.oauth_configured(self.cornerstone_config) is False
+
+    def test_oauth_configured_true_when_credentials_set(self):
+        """
+        Test that oauth_configured is True when both client id and secret are set.
+        """
+        self.cornerstone_config.decrypted_client_id = 'my-client-id'
+        self.cornerstone_config.decrypted_client_secret = 'my-client-secret'
+        self.cornerstone_config.save()
+        assert self.admin_instance.oauth_configured(self.cornerstone_config) is True
+
+
+@mark.django_db
+class TestCornerstoneLearnerDataTransmissionAuditAdmin(TestCase):
+    """
+    Tests for the ``CornerstoneLearnerDataTransmissionAuditAdmin`` admin class.
+    """
+
+    def setUp(self):
+        """
+        Set up test data.
+        """
+        super().setUp()
+        self.admin_site = AdminSite()
+        self.admin_instance = CornerstoneLearnerDataTransmissionAuditAdmin(
+            CornerstoneLearnerDataTransmissionAudit, self.admin_site
+        )
+        self.user = factories.UserFactory()
+        self.audit = factories.CornerstoneLearnerDataTransmissionAuditFactory(user=self.user)
+
+    def test_user_email(self):
+        """
+        Test the user_email method returns the associated user's email.
+        """
+        assert self.admin_instance.user_email(self.audit) == self.user.email

--- a/tests/test_channel_integrations/test_cornerstone/test_client.py
+++ b/tests/test_channel_integrations/test_cornerstone/test_client.py
@@ -4,6 +4,7 @@ Tests for Degreed2 client for channel_integrations.
 
 import json
 import unittest
+from urllib.parse import urljoin
 
 import pytest
 import responses
@@ -11,6 +12,8 @@ import responses
 from django.apps import apps
 
 from channel_integrations.cornerstone.client import CornerstoneAPIClient
+from channel_integrations.cornerstone.utils import get_or_create_key_pair
+from channel_integrations.exceptions import ClientError
 from test_utils import factories
 
 IntegratedChannelAPIRequestLogs = apps.get_model(
@@ -60,3 +63,171 @@ class TestCornerstoneApiClient(unittest.TestCase):
         assert IntegratedChannelAPIRequestLogs.objects.count() == 1
         assert len(responses.calls) == 1
         assert output == (200, '"{}"')
+
+    def _migrate_config_to_oauth(self):
+        """
+        Give the config OAuth credentials, which routes completions to the Transcript API.
+        """
+        self.csod_config.decrypted_client_id = "dummy_client_id"
+        self.csod_config.decrypted_client_secret = "dummy_client_secret"
+        self.csod_config.save()
+
+    def _transcript_url(self, client):
+        return urljoin(self.cornerstone_base_url, client.TRANSCRIPT_COMPLETE_API_PATH)
+
+    @staticmethod
+    def _completion_payload(**overrides):
+        data = {
+            "userGuid": "dummy_guid",
+            "courseId": "edX+DemoX",
+            "status": "Completed",
+            "successStatus": "Pass",
+            "sessionToken": "expired_session_token",
+            "callbackUrl": "dummy_callback_url",
+            "subdomain": "dummy_subdomain",
+        }
+        data.update(overrides)
+        return json.dumps({"data": data})
+
+    @responses.activate
+    def test_completion_goes_to_the_transcript_api_once_migrated(self):
+        """
+        With OAuth credentials configured, a completion should PATCH the Transcript API with a
+        bearer token, and carry no session token anywhere.
+        """
+        self._migrate_config_to_oauth()
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+        transcript_url = self._transcript_url(cornerstone_api_client)
+
+        responses.add(
+            responses.POST,
+            cornerstone_api_client.get_oauth_url(),
+            json={"access_token": "dummy_access_token", "expires_in": 3600},
+            status=200,
+        )
+        responses.add(responses.PATCH, transcript_url, json="{}", status=200)
+
+        output = cornerstone_api_client.create_course_completion(
+            "test-learner@example.com", self._completion_payload()
+        )
+
+        assert output == (200, '"{}"')
+        assert len(responses.calls) == 2
+
+        token_request = responses.calls[0]
+        transcript_request = responses.calls[1]
+        assert "client_credentials" in token_request.request.body
+        assert transcript_request.request.method == "PATCH"
+        assert transcript_request.request.url == transcript_url
+        assert transcript_request.request.headers["Authorization"] == "Bearer dummy_access_token"
+
+        body = json.loads(transcript_request.request.body)
+        assert body["userGuid"] == "dummy_guid"
+        assert body["ignoreWorkflow"] is True
+        # The learning object is keyed on the id we publish in the course-list feed.
+        assert body["learningObjectId"] == get_or_create_key_pair("edX+DemoX").external_course_id
+        assert "sessionToken" not in body
+        assert "sessionToken" not in transcript_request.request.url
+
+        # The token request body and the token itself are kept out of the stored API record.
+        token_record = IntegratedChannelAPIRequestLogs.objects.get(endpoint=token_request.request.url)
+        assert "dummy_client_secret" not in token_record.payload
+        assert "dummy_access_token" not in token_record.response_body
+
+    @responses.activate
+    def test_in_progress_records_are_skipped_on_the_transcript_api(self):
+        """
+        The Transcript API's completion endpoint only marks transcripts complete, so a record that
+        is still in progress should be skipped rather than sent.
+        """
+        self._migrate_config_to_oauth()
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+
+        output = cornerstone_api_client.create_course_completion(
+            "test-learner@example.com",
+            self._completion_payload(status="In Progress", successStatus=None),
+        )
+
+        assert output == (200, '')
+        assert len(responses.calls) == 0
+        assert IntegratedChannelAPIRequestLogs.objects.count() == 0
+
+    @responses.activate
+    def test_unmigrated_config_still_uses_the_legacy_callback(self):
+        """
+        A config with no OAuth credentials should keep posting to the launch-time callback URL.
+        """
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+        responses.add(
+            responses.POST,
+            f"{self.cornerstone_base_url}dummy_callback_url",
+            json="{}",
+            status=200,
+        )
+
+        output = cornerstone_api_client.create_course_completion(
+            "test-learner@example.com", self._completion_payload()
+        )
+
+        assert output == (200, '"{}"')
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.method == "POST"
+        assert "sessionToken=expired_session_token" in responses.calls[0].request.url
+
+    @responses.activate
+    def test_create_course_completion_reuses_unexpired_access_token(self):
+        """
+        A second completion in the same client's lifetime should reuse the existing access token.
+        """
+        self._migrate_config_to_oauth()
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+
+        responses.add(
+            responses.POST,
+            cornerstone_api_client.get_oauth_url(),
+            json={"access_token": "dummy_access_token", "expires_in": 3600},
+            status=200,
+        )
+        responses.add(
+            responses.PATCH,
+            self._transcript_url(cornerstone_api_client),
+            json="{}",
+            status=200,
+        )
+
+        cornerstone_api_client.create_course_completion(
+            "test-learner@example.com", self._completion_payload()
+        )
+        cornerstone_api_client.create_course_completion(
+            "test-learner@example.com", self._completion_payload()
+        )
+
+        token_calls = [
+            call for call in responses.calls
+            if call.request.url == cornerstone_api_client.get_oauth_url()
+        ]
+        assert len(token_calls) == 1
+
+    @responses.activate
+    def test_get_oauth_access_token_raises_on_unparseable_response(self):
+        """
+        A token endpoint that does not hand back an ``access_token`` should raise a ``ClientError``.
+        """
+        self.csod_config.decrypted_client_id = "dummy_client_id"
+        self.csod_config.decrypted_client_secret = "dummy_client_secret"
+        self.csod_config.save()
+
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+        responses.add(
+            responses.POST,
+            cornerstone_api_client.get_oauth_url(),
+            json={"error": "invalid_client"},
+            status=401,
+        )
+
+        with pytest.raises(ClientError):
+            cornerstone_api_client._get_oauth_access_token()  # pylint: disable=protected-access
+
+        # Failures keep their response body, which is what we debug on.
+        token_record = IntegratedChannelAPIRequestLogs.objects.get()
+        assert "invalid_client" in token_record.response_body

--- a/tests/test_channel_integrations/test_cornerstone/test_client.py
+++ b/tests/test_channel_integrations/test_cornerstone/test_client.py
@@ -134,14 +134,78 @@ class TestCornerstoneApiClient(unittest.TestCase):
         assert "dummy_client_secret" not in token_record.payload
         assert "dummy_access_token" not in token_record.response_body
 
+    def _assignments_url(self, client):
+        return urljoin(self.cornerstone_base_url, client.LEARNING_ASSIGNMENTS_API_PATH)
+
     @responses.activate
-    def test_in_progress_records_are_skipped_on_the_transcript_api(self):
+    def test_in_progress_records_go_to_the_learning_assignments_api(self):
         """
-        The Transcript API's completion endpoint only marks transcripts complete, so a record that
-        is still in progress should be skipped rather than sent.
+        In-progress records are routed to the Learning Assignments API rather than the Transcript
+        API, since the Transcript API only understands completions.
         """
         self._migrate_config_to_oauth()
         cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+        assignments_url = self._assignments_url(cornerstone_api_client)
+
+        responses.add(
+            responses.POST,
+            cornerstone_api_client.get_oauth_url(),
+            json={"access_token": "dummy_access_token", "expires_in": 3600},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            assignments_url,
+            json=[{"assignmentId": "dummy_assignment_id"}],
+            status=200,
+        )
+        responses.add(
+            responses.PATCH,
+            f"{assignments_url}/dummy_assignment_id",
+            json="{}",
+            status=200,
+        )
+
+        output = cornerstone_api_client.create_course_completion(
+            "test-learner@example.com",
+            self._completion_payload(status="In Progress", successStatus=None),
+        )
+
+        assert output == (200, '"{}"')
+
+        lookup_request = responses.calls[1]
+        assert lookup_request.request.method == "GET"
+        assert "userId=dummy_guid" in lookup_request.request.url
+        assert "loId=" in lookup_request.request.url
+
+        update_request = responses.calls[2]
+        assert update_request.request.method == "PATCH"
+        assert update_request.request.url == f"{assignments_url}/dummy_assignment_id"
+        body = json.loads(update_request.request.body)
+        assert body["Status"] == "In Progress"
+
+    @responses.activate
+    def test_in_progress_records_are_skipped_when_no_assignment_found(self):
+        """
+        If Cornerstone has no matching assignment for this learner/course, the update is skipped
+        rather than raising.
+        """
+        self._migrate_config_to_oauth()
+        cornerstone_api_client = CornerstoneAPIClient(self.csod_config)
+        assignments_url = self._assignments_url(cornerstone_api_client)
+
+        responses.add(
+            responses.POST,
+            cornerstone_api_client.get_oauth_url(),
+            json={"access_token": "dummy_access_token", "expires_in": 3600},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            assignments_url,
+            json=[],
+            status=200,
+        )
 
         output = cornerstone_api_client.create_course_completion(
             "test-learner@example.com",
@@ -149,8 +213,7 @@ class TestCornerstoneApiClient(unittest.TestCase):
         )
 
         assert output == (200, '')
-        assert len(responses.calls) == 0
-        assert IntegratedChannelAPIRequestLogs.objects.count() == 0
+        assert len(responses.calls) == 2
 
     @responses.activate
     def test_unmigrated_config_still_uses_the_legacy_callback(self):

--- a/tests/test_channel_integrations/test_cornerstone/test_models.py
+++ b/tests/test_channel_integrations/test_cornerstone/test_models.py
@@ -127,3 +127,53 @@ class TestCornerstoneEnterpriseCustomerConfiguration(unittest.TestCase):
         self.config.save()
         with raises(ValidationError):
             self.config.clean()
+
+    def test_encrypted_client_id(self):
+        """
+        Test the encrypted_client_id property getter and setter.
+        """
+        assert self.config.encrypted_client_id == ''
+
+        self.config.decrypted_client_id = 'my-client-id'
+        encrypted_value = self.config.encrypted_client_id
+        assert encrypted_value != 'my-client-id'
+        assert isinstance(encrypted_value, str)
+
+        self.config.encrypted_client_id = encrypted_value
+        assert self.config.decrypted_client_id == encrypted_value
+
+    def test_encrypted_client_secret(self):
+        """
+        Test the encrypted_client_secret property getter and setter.
+        """
+        assert self.config.encrypted_client_secret == ''
+
+        self.config.decrypted_client_secret = 'my-client-secret'
+        encrypted_value = self.config.encrypted_client_secret
+        assert encrypted_value != 'my-client-secret'
+        assert isinstance(encrypted_value, str)
+
+        self.config.encrypted_client_secret = encrypted_value
+        assert self.config.decrypted_client_secret == encrypted_value
+
+    def test_uses_oauth_completion_auth(self):
+        """
+        Test the uses_oauth_completion_auth property.
+        """
+        assert self.config.uses_oauth_completion_auth is False
+
+        self.config.decrypted_client_id = 'my-client-id'
+        assert self.config.uses_oauth_completion_auth is False
+
+        self.config.decrypted_client_secret = 'my-client-secret'
+        assert self.config.uses_oauth_completion_auth is True
+
+    def test_str_and_repr(self):
+        """
+        Test the __str__ and __repr__ methods.
+        """
+        expected = "<CornerstoneEnterpriseCustomerConfiguration for Enterprise {}>".format(
+            self.enterprise_customer.name
+        )
+        assert str(self.config) == expected
+        assert repr(self.config) == expected


### PR DESCRIPTION
## [ENT-12018](https://2u-internal.atlassian.net/browse/ENT-12018) Fix ARH course not transmitting to CSOD

### Problem

ARH customer's course (`StanfordOnline+WEL`) is not transmitting to Cornerstone (CSOD). 
The admin portal shows the transmission stuck in "pending" status.

**Root Cause:** CSOD completions are POSTed to the callback URL authenticated with a 
`sessionToken` from the learner's launch. That token lasts ~2 hours, is never refreshed, 
and completions are sent hours/days later — so the token is dead by the time we use it, 
and Cornerstone returns **401 "Check your credentials"**.

Investigation doc: https://2u-internal.atlassian.net/wiki/spaces/SOL/pages/3895918630/CSOD+Learner-Data+Transmission+Failure+-+Investigation

### Solution

Migrate the CSOD learner data transmission from the expired session-token approach to 
**OAuth client credentials** with proper API endpoints:

#### 1. Completions → Transcript API (OAuth)
- Authenticate with OAuth client credentials (mint and refresh ourselves)
- `PATCH /services/api/v1/transcripts/complete` for completed learner records
- Two new encrypted per-customer credential fields (`client_id`/`client_secret`) on 
  CSOD config, matching the Degreed2/SAP pattern
- Writable through the config API and Django admin

#### 2. In-Progress → Learning Assignments API (OAuth)
- `GET /services/api/v1/LearningAssignments?userId={userGuid}&loId={loId}` to resolve 
  the assignment
- `PATCH /services/api/v1/LearningAssignments/{assignmentId}` with Status and 
  LastAccessDate for in-progress records
- Uses the same OAuth session — no additional auth plumbing needed

#### Routing Logic
```python
if uses_oauth_completion_auth:
    if status == "Completed":
        → _complete_transcript()        # Transcript API
    else:
        → _update_learning_assignment() # Assignments API
else:
    → _post_completion_callback()       # Legacy session-token path